### PR TITLE
feat(scheduler): 前端系统级调度支持 — 唤醒开关/来源徽标/冲突对话

### DIFF
--- a/front/src/app/App.vue
+++ b/front/src/app/App.vue
@@ -45,7 +45,12 @@
             :name="typeof r.meta.transition === 'string' ? r.meta.transition : 'fade'"
             mode="out-in"
           >
-            <component :is="Component" />
+            <!-- Key by route name: guarantees unmount/remount across routes so
+                 multi-root views (e.g. TasksView) never leak sibling nodes into
+                 the next route under transition mode="out-in". -->
+            <div :key="r.name">
+              <component :is="Component" />
+            </div>
           </transition>
         </router-view>
       </div>

--- a/front/src/app/i18n/messages/en-US.json
+++ b/front/src/app/i18n/messages/en-US.json
@@ -191,7 +191,8 @@
         "title": "Start Conflict",
         "updateInProgress": "An update is in progress. Please try again later.",
         "busyMessage": "Task \"{name}\" is currently running.",
-        "stopAndRestart": "Stop and restart"
+        "stopAndRestart": "Stop and restart",
+        "stopTimeout": "Stop timed out: the previous task did not exit in time. Start manually later."
       },
       "rules": {
         "nameRequired": "Please enter task name",

--- a/front/src/app/i18n/messages/en-US.json
+++ b/front/src/app/i18n/messages/en-US.json
@@ -93,13 +93,20 @@
       "title": "Scheduler",
       "create": "New Task",
       "taskList": "Task List",
+      "list": {
+        "runsWhenClosed": "Runs when closed"
+      },
       "noTasks": "No scheduled tasks",
       "trigger": "Trigger",
       "nextRun": "Next Run",
-      "history": "Execution History",
+      "historyTitle": "Execution History",
       "noHistory": "No execution records",
       "deleteConfirm": "Are you sure you want to delete this task?",
       "deleted": "Task deleted",
+      "history": {
+        "scheduledFor": "Scheduled",
+        "skippedBy": "Skipped by: {name}"
+      },
       "formatter": {
         "cron": "Cron",
         "date": "Specific Time",
@@ -115,7 +122,16 @@
         "success": "Success",
         "failed": "Failed",
         "running": "Running",
-        "stopped": "Stopped"
+        "stopped": "Stopped",
+        "skippedBusyManual": "Skipped (manual busy)",
+        "skippedBusyScheduled": "Skipped (scheduled busy)",
+        "skippedUpdateInProgress": "Skipped (updating)",
+        "missedDeadline": "Missed deadline"
+      },
+      "origin": {
+        "manual": "Manual",
+        "inApp": "In-app",
+        "native": "Native"
       },
       "dialog": {
         "editTitle": "Edit Task",
@@ -161,6 +177,8 @@
         "controller": "Controller",
         "deviceAddress": "Device Address",
         "resource": "Resource",
+        "runWhenClosed": "Run when app is closed (OS wake)",
+        "runWhenClosedIneligible": "Current cron is not eligible for OS wake (needs fixed minute; day/weekday mutually exclusive)",
         "sections": {
           "nav": "Sections",
           "basic": "Basic Info",
@@ -168,6 +186,12 @@
           "environment": "Environment",
           "content": "Tasks"
         }
+      },
+      "conflict": {
+        "title": "Start Conflict",
+        "updateInProgress": "An update is in progress. Please try again later.",
+        "busyMessage": "Task \"{name}\" is currently running.",
+        "stopAndRestart": "Stop and restart"
       },
       "rules": {
         "nameRequired": "Please enter task name",

--- a/front/src/app/i18n/messages/zh-CN.json
+++ b/front/src/app/i18n/messages/zh-CN.json
@@ -93,13 +93,20 @@
       "title": "定时任务",
       "create": "新建任务",
       "taskList": "任务列表",
+      "list": {
+        "runsWhenClosed": "关闭后仍运行"
+      },
       "noTasks": "暂无定时任务",
       "trigger": "触发",
       "nextRun": "下次执行",
-      "history": "执行历史",
+      "historyTitle": "执行历史",
       "noHistory": "暂无执行记录",
       "deleteConfirm": "确定要删除这个定时任务吗？",
       "deleted": "任务已删除",
+      "history": {
+        "scheduledFor": "计划",
+        "skippedBy": "被占用跳过：{name}"
+      },
       "formatter": {
         "cron": "Cron",
         "date": "指定时间",
@@ -115,7 +122,16 @@
         "success": "成功",
         "failed": "失败",
         "running": "运行中",
-        "stopped": "已停止"
+        "stopped": "已停止",
+        "skippedBusyManual": "已跳过（手动任务占用）",
+        "skippedBusyScheduled": "已跳过（调度任务占用）",
+        "skippedUpdateInProgress": "已跳过（更新中）",
+        "missedDeadline": "错过截止时间"
+      },
+      "origin": {
+        "manual": "手动",
+        "inApp": "应用内",
+        "native": "系统"
       },
       "dialog": {
         "editTitle": "编辑定时任务",
@@ -161,6 +177,8 @@
         "controller": "控制器",
         "deviceAddress": "设备地址",
         "resource": "资源",
+        "runWhenClosed": "关闭后仍运行（系统级唤醒）",
+        "runWhenClosedIneligible": "当前 cron 不支持系统级唤醒（分钟须为具体值，日与星期不可同时限定）",
         "sections": {
           "nav": "配置分区",
           "basic": "基本信息",
@@ -168,6 +186,12 @@
           "environment": "运行环境",
           "content": "执行内容"
         }
+      },
+      "conflict": {
+        "title": "启动冲突",
+        "updateInProgress": "应用正在更新，请稍后再试",
+        "busyMessage": "任务「{name}」正在运行",
+        "stopAndRestart": "停止并重启"
       },
       "rules": {
         "nameRequired": "请输入任务名称",

--- a/front/src/app/i18n/messages/zh-CN.json
+++ b/front/src/app/i18n/messages/zh-CN.json
@@ -191,7 +191,8 @@
         "title": "启动冲突",
         "updateInProgress": "应用正在更新，请稍后再试",
         "busyMessage": "任务「{name}」正在运行",
-        "stopAndRestart": "停止并重启"
+        "stopAndRestart": "停止并重启",
+        "stopTimeout": "停止超时：上一个任务未能及时退出，请稍后手动启动"
       },
       "rules": {
         "nameRequired": "请输入任务名称",

--- a/front/src/components/common/CreatableSelect.vue
+++ b/front/src/components/common/CreatableSelect.vue
@@ -7,7 +7,8 @@
       :aria-expanded="isOpen"
       :aria-controls="isOpen ? listboxId : undefined"
       :value="displayValue"
-      class="select select-sm w-full"
+      class="select w-full"
+      :class="size === 'sm' ? 'select-sm' : ''"
       :placeholder="placeholder"
       :disabled="disabled"
       @focus="handleFocus"
@@ -61,10 +62,17 @@ interface Option {
   disabled?: boolean
 }
 
-const { options, placeholder, disabled } = defineProps<{
+const {
+  options,
+  placeholder,
+  disabled,
+  size = "sm",
+} = defineProps<{
   options: Option[]
   placeholder?: string
   disabled?: boolean
+  /** sm: compact (panel rows); md: default DaisyUI size (settings dialogs) */
+  size?: "sm" | "md"
 }>()
 
 const modelValue = defineModel<string | null>()

--- a/front/src/components/home/RoutineHealthCard.vue
+++ b/front/src/components/home/RoutineHealthCard.vue
@@ -17,7 +17,7 @@
         <div class="flex-1 min-w-0">
           <div class="text-sm font-medium truncate">{{ task.name }}</div>
           <div class="text-xs opacity-60">
-            {{ formatTriggerText(task.trigger_type, task.trigger_config) }}
+            {{ formatTriggerText(task.trigger_config) }}
           </div>
         </div>
         <div class="text-xs opacity-60 shrink-0">
@@ -74,7 +74,7 @@ import { useI18n } from "vue-i18n"
 import { Icon } from "@iconify/vue"
 import { useSchedulerStore } from "@/stores"
 import { formatDateTime, formatTrigger } from "@/utils/scheduler/display"
-import type { TriggerConfig, TriggerType } from "@/types/schedulerModel"
+import type { TriggerConfig } from "@/types/schedulerModel"
 
 const { t, locale } = useI18n()
 const schedulerStore = useSchedulerStore()
@@ -87,8 +87,8 @@ const healthScore = computed(() => {
 
 const healthScoreText = computed(() => `${healthScore.value}%`)
 
-function formatTriggerText(triggerType: TriggerType, triggerConfig: TriggerConfig): string {
-  return formatTrigger(t, locale.value, triggerType, triggerConfig)
+function formatTriggerText(triggerConfig: TriggerConfig): string {
+  return formatTrigger(t, locale.value, triggerConfig.type, triggerConfig)
 }
 
 function formatDateTimeText(dateStr?: string): string {

--- a/front/src/components/panel/task/TaskSelectList.vue
+++ b/front/src/components/panel/task/TaskSelectList.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="bg-base-100 rounded-lg overflow-hidden">
+  <div
+    class="bg-base-100 rounded-lg overflow-hidden"
+    :class="{ 'overflow-y-auto': maxHeight }"
+    :style="maxHeight ? { maxHeight } : undefined"
+  >
     <VueDraggable v-model="taskListData" :animation="150" ghost-class="ghost">
       <div
         v-for="(item, index) in taskListData"
@@ -51,6 +55,7 @@ interface Props {
   controllerName?: string | null
   resourceName?: string | null
   hideIncompatible?: boolean
+  maxHeight?: string
 }
 
 interface Emits {
@@ -65,6 +70,7 @@ const {
   controllerName = null,
   resourceName = null,
   hideIncompatible = false,
+  maxHeight = "",
 } = defineProps<Props>()
 
 const emit = defineEmits<Emits>()

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -360,6 +360,7 @@
               :options="deviceAddressOptions"
               :placeholder="t('panel.selectDevice')"
               :disabled="!formData.controller_name || loadingDevices"
+              size="md"
               @create="handleCustomDeviceCreate"
             />
           </fieldset>

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -781,6 +781,13 @@ watch(
   },
 )
 
+// cron 从合格变为不合格时同步清空唤醒开关，避免隐藏值随提交被静默屏蔽
+watch(isCronNativeEligible, (eligible) => {
+  if (!eligible) {
+    wakeupEnabled.value = false
+  }
+})
+
 watch(
   () => formData.value.controller_name,
   (newVal, oldVal) => {

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -107,10 +107,11 @@
                 class="border-base-300 hover:border-primary/40 has-[:checked]:border-primary has-[:checked]:bg-primary/5 flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 transition-colors"
               >
                 <input
-                  v-model="formData.trigger_type"
+                  :checked="triggerType === option.value"
                   type="radio"
                   class="radio radio-primary radio-sm"
                   :value="option.value"
+                  @change="setTriggerType(option.value)"
                 />
                 <Icon :icon="option.icon" class="text-base opacity-70" aria-hidden="true" />
                 <span class="text-sm">{{ option.label }}</span>
@@ -120,7 +121,7 @@
 
           <!-- Schedule: cron -->
           <fieldset
-            v-if="activeSection === 'schedule' && formData.trigger_type === 'cron'"
+            v-if="activeSection === 'schedule' && triggerType === 'cron'"
             class="fieldset p-0"
           >
             <legend class="fieldset-legend">
@@ -136,7 +137,7 @@
             />
           </fieldset>
           <div
-            v-if="activeSection === 'schedule' && formData.trigger_type === 'cron'"
+            v-if="activeSection === 'schedule' && triggerType === 'cron'"
             class="flex flex-wrap gap-2"
           >
             <span class="text-base-content/50 self-center text-xs">
@@ -156,9 +157,31 @@
             </button>
           </div>
 
+          <!-- Schedule: wakeup -->
+          <fieldset
+            v-if="activeSection === 'schedule' && triggerType === 'cron'"
+            class="fieldset p-0"
+          >
+            <legend class="fieldset-legend flex items-center gap-1.5">
+              <Icon icon="mdi:power-sleep" class="text-base opacity-70" aria-hidden="true" />
+              {{ t("settings.scheduler.dialog.runWhenClosed") }}
+            </legend>
+            <div class="flex flex-wrap items-center gap-3">
+              <input
+                v-model="wakeupEnabled"
+                type="checkbox"
+                class="toggle toggle-primary"
+                :disabled="!isCronNativeEligible"
+              />
+              <span v-if="!isCronNativeEligible" class="text-warning text-xs">
+                {{ t("settings.scheduler.dialog.runWhenClosedIneligible") }}
+              </span>
+            </div>
+          </fieldset>
+
           <!-- Schedule: date -->
           <fieldset
-            v-if="activeSection === 'schedule' && formData.trigger_type === 'date'"
+            v-if="activeSection === 'schedule' && triggerType === 'date'"
             class="fieldset p-0"
           >
             <legend class="fieldset-legend">
@@ -178,7 +201,7 @@
 
           <!-- Schedule: interval duration -->
           <fieldset
-            v-if="activeSection === 'schedule' && formData.trigger_type === 'interval'"
+            v-if="activeSection === 'schedule' && triggerType === 'interval'"
             class="fieldset p-0"
           >
             <legend class="fieldset-legend">
@@ -264,7 +287,7 @@
 
           <!-- Schedule: interval start/end -->
           <div
-            v-if="activeSection === 'schedule' && formData.trigger_type === 'interval'"
+            v-if="activeSection === 'schedule' && triggerType === 'interval'"
             class="grid grid-cols-1 gap-3 sm:grid-cols-2"
           >
             <fieldset class="fieldset p-0">
@@ -478,6 +501,7 @@ import { resolveInterfaceText } from "@/utils/interface/content"
 import { getDevices, getResource } from "@/services/api"
 import type { ConnectableDevice, DeviceControllerType } from "@/services/api"
 import { buildDeviceLabel } from "@/utils/panel/device"
+import { checkCronNativeEligibility } from "@/utils/scheduler/cronNative"
 import type { PanelLastConnectedDevice } from "@/types/settingsModel"
 import type {
   ScheduledTask,
@@ -520,6 +544,7 @@ const activeSection = ref<DialogSection>("basic")
 const activeTab = ref<"task-list" | "task-settings" | "pre-tasks">("task-list")
 const currentSettingTaskId = ref<string | null>(null)
 const suppressFormInit = ref(false)
+const wakeupEnabled = ref(false)
 
 const availableDevices = ref<ConnectableDevice[]>([])
 const availableResources = ref<Array<{ name: string; label?: string; controller?: string[] }>>([])
@@ -700,8 +725,16 @@ const intervalConfig = computed<IntervalTriggerConfig>(() => {
 const intervalStartLocal = computed(() => toDatetimeLocalValue(intervalConfig.value.start_date))
 const intervalEndLocal = computed(() => toDatetimeLocalValue(intervalConfig.value.end_date))
 
-const formData = ref<ScheduledTaskCreate>(initFormData(task))
+type SchedulerTaskFormData = Omit<ScheduledTaskCreate, "wakeup_enabled">
+
+const formData = ref<SchedulerTaskFormData>(initFormData(task))
 const taskListData = ref<TaskListItem[]>([])
+
+const triggerType = computed(() => formData.value.trigger_config.type)
+const isCronNativeEligible = computed(() => {
+  const config = formData.value.trigger_config
+  return config.type === "cron" && checkCronNativeEligibility(config.cron)
+})
 
 function syncDialogVisibility(open: boolean) {
   const el = dialogRef.value
@@ -735,13 +768,6 @@ onMounted(() => {
     syncDialogVisibility(true)
   }
 })
-
-watch(
-  () => formData.value.trigger_type,
-  (newType) => {
-    formData.value.trigger_config = getTriggerConfigByType(newType)
-  },
-)
 
 watch(
   () => task,
@@ -860,15 +886,15 @@ function handleTasksUpdate(tasks: TaskListItem[]) {
   formData.value.task_list = buildOrderedTaskList(formData.value.task_list, tasks)
 }
 
-function initFormData(task?: ScheduledTask | null): ScheduledTaskCreate {
+function initFormData(task?: ScheduledTask | null): SchedulerTaskFormData {
+  wakeupEnabled.value = task ? (task.wakeup_enabled ?? false) : false
   if (task) {
     const task_list = configStore.normalizeTaskIds(task.task_list)
     return {
       name: task.name,
       description: task.description || "",
       enabled: task.enabled,
-      trigger_type: task.trigger_type,
-      trigger_config: getTriggerConfigByType(task.trigger_type, task.trigger_config),
+      trigger_config: getTriggerConfigByType(task.trigger_config.type, task.trigger_config),
       task_list,
       task_options: configStore.buildOptionsForTasks(task_list, task.task_options),
       preTasks: Array.isArray(task.preTasks) ? task.preTasks.map((pt) => ({ ...pt })) : [],
@@ -881,7 +907,6 @@ function initFormData(task?: ScheduledTask | null): ScheduledTaskCreate {
     name: "",
     description: "",
     enabled: true,
-    trigger_type: "cron",
     trigger_config: getTriggerConfigByType("cron"),
     task_list: [],
     task_options: configStore.buildOptionsForTasks([]),
@@ -948,6 +973,13 @@ function getTriggerConfigByType(
       return buildIntervalConfig(existing)
     default:
       return buildCronConfig()
+  }
+}
+
+function setTriggerType(newType: TriggerType) {
+  formData.value.trigger_config = getTriggerConfigByType(newType)
+  if (newType !== "cron") {
+    wakeupEnabled.value = false
   }
 }
 
@@ -1152,14 +1184,13 @@ function validateForm(): boolean {
   if (!validateName()) {
     return false
   }
-  const { trigger_type } = formData.value
-  if (trigger_type === "cron" && !validateCron()) {
+  if (triggerType.value === "cron" && !validateCron()) {
     return false
   }
-  if (trigger_type === "date" && !validateDate()) {
+  if (triggerType.value === "date" && !validateDate()) {
     return false
   }
-  if (trigger_type === "interval" && !validateInterval()) {
+  if (triggerType.value === "interval" && !validateInterval()) {
     return false
   }
   return validateTaskList()
@@ -1173,16 +1204,20 @@ async function handleSave() {
   loading.value = true
   const taskPayload = {
     ...formData.value,
+    wakeup_enabled:
+      triggerType.value === "cron" && isCronNativeEligible.value ? wakeupEnabled.value : false,
     ...configStore.buildExecutionPayload(formData.value.task_list, formData.value.task_options),
     preTasks: formData.value.preTasks ?? [],
   }
-  const [success, err] = await tryCatch(() =>
-    isEditMode.value && task
-      ? schedulerStore.updateTask(task.id, taskPayload)
-      : schedulerStore.createTask(taskPayload),
-  )
+  const [savedTask, err] = await tryCatch(async () => {
+    if (isEditMode.value && task) {
+      const ok = await schedulerStore.updateTask(task.id, taskPayload)
+      return ok ? task : null
+    }
+    return schedulerStore.createTask(taskPayload)
+  })
   loading.value = false
-  if (err || !success) {
+  if (err || !savedTask) {
     showGlobalMessage("error", schedulerStore.error || t("settings.scheduler.dialog.saveFail"))
     return
   }

--- a/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
+++ b/front/src/components/settings/dialogs/SchedulerTaskDialog.vue
@@ -6,7 +6,8 @@
     @close="onNativeClose"
   >
     <div
-      class="modal-box flex h-[min(92dvh,720px)] w-full max-w-4xl flex-col p-0 sm:h-auto sm:max-h-[90vh]"
+      class="modal-box flex h-[min(92dvh,540px)] w-full max-w-4xl flex-col p-0 sm:h-[min(90dvh,540px)] sm:max-h-none"
+      :style="dialogBoxStyle"
     >
       <!-- Header -->
       <header
@@ -333,7 +334,7 @@
               class="select select-bordered w-full"
               :disabled="loadingDevices"
             >
-              <option value="">{{ t("panel.selectDeviceType") }}</option>
+              <option value="" disabled>{{ t("panel.selectDeviceType") }}</option>
               <option v-for="opt in deviceControllerOptions" :key="opt.value" :value="opt.value">
                 {{ opt.label }}
               </option>
@@ -353,17 +354,14 @@
               :placeholder="t('panel.playcoverAddress')"
               :disabled="!formData.controller_name"
             />
-            <select
+            <CreatableSelect
               v-else
               v-model="selectedDeviceAddress"
-              class="select select-bordered w-full"
+              :options="deviceAddressOptions"
+              :placeholder="t('panel.selectDevice')"
               :disabled="!formData.controller_name || loadingDevices"
-            >
-              <option value="">{{ t("panel.selectDevice") }}</option>
-              <option v-for="opt in deviceAddressOptions" :key="opt.value" :value="opt.value">
-                {{ opt.label }}
-              </option>
-            </select>
+              @create="handleCustomDeviceCreate"
+            />
           </fieldset>
 
           <fieldset v-if="activeSection === 'environment'" class="fieldset p-0">
@@ -376,7 +374,7 @@
               class="select select-bordered w-full"
               :disabled="!formData.controller_name || loadingResources"
             >
-              <option value="">{{ t("panel.selectResource") }}</option>
+              <option value="" disabled>{{ t("panel.selectResource") }}</option>
               <option v-for="opt in resourceOptions" :key="opt.value" :value="opt.value">
                 {{ opt.label }}
               </option>
@@ -438,6 +436,7 @@
                   :controller-name="formData.controller_name"
                   :resource-name="formData.resource_name"
                   :hide-incompatible="true"
+                  max-height="20rem"
                   @update:tasks="handleTasksUpdate"
                   @update:selected-tasks="handleSelectedTasksUpdate"
                   @config="openTaskSettings"
@@ -498,8 +497,8 @@ import TaskSelectList from "@/components/panel/task/TaskSelectList.vue"
 import TaskOptionPanel from "@/components/panel/task/TaskOptionPanel.vue"
 import PreTaskList from "@/components/panel/task/PreTaskList.vue"
 import { resolveInterfaceText } from "@/utils/interface/content"
-import { getDevices, getResource } from "@/services/api"
-import type { ConnectableDevice, DeviceControllerType } from "@/services/api"
+import { getDevices, getResource, postCustomDevice } from "@/services/api"
+import type { ConnectableDevice } from "@/services/api"
 import { buildDeviceLabel } from "@/utils/panel/device"
 import { checkCronNativeEligibility } from "@/utils/scheduler/cronNative"
 import type { PanelLastConnectedDevice } from "@/types/settingsModel"
@@ -514,6 +513,8 @@ import type {
 } from "@/types/schedulerModel"
 import { showGlobalMessage } from "@/services/feedback/message"
 import { tryCatch } from "@/utils/tryCatch"
+import { useViewport } from "@/utils/viewport/useViewport"
+import CreatableSelect from "@/components/common/CreatableSelect.vue"
 
 interface Props {
   show: boolean
@@ -539,6 +540,15 @@ const settingsStore = useSettingsStore()
 const dialogRef = useTemplateRef<HTMLDialogElement>("dialogRef")
 const loading = ref(false)
 const closingFromUi = ref(false)
+
+const { isMobile, width: viewportWidth } = useViewport()
+
+/** On desktop, fix the dialog to a viewport-derived size so it never grows/shrinks with content. */
+const dialogBoxStyle = computed(() => {
+  if (isMobile.value) return undefined
+  const w = Math.min(Math.round(viewportWidth.value * 0.72), 960)
+  return { width: `${w}px`, maxWidth: "none" }
+})
 
 const activeSection = ref<DialogSection>("basic")
 const activeTab = ref<"task-list" | "task-settings" | "pre-tasks">("task-list")
@@ -1090,6 +1100,32 @@ async function fetchResources(controllerType: string) {
     return
   }
   availableResources.value = data
+}
+
+/** Persist a user-typed device address as a custom device and select it. */
+async function handleCustomDeviceCreate(rawAddress: string) {
+  const controllerName = formData.value.controller_name
+  const controllerType = selectedControllerType.value
+  if (!controllerName || !controllerType || !isDeviceControllerType(controllerType)) return
+
+  const address = rawAddress.trim()
+  if (!address) return
+
+  const [result, err] = await tryCatch(() =>
+    postCustomDevice({
+      controller_name: controllerName,
+      type: controllerType,
+      address,
+    }),
+  )
+  if (err || !result?.success) {
+    showGlobalMessage("error", result?.message || t("settings.scheduler.dialog.saveFail"))
+    return
+  }
+
+  // Refresh device list so the new device appears, then select it
+  await fetchDevices(controllerName)
+  selectedDeviceAddress.value = address
 }
 
 function validateName(): boolean {

--- a/front/src/components/settings/scheduler/SchedulerExecutionHistory.vue
+++ b/front/src/components/settings/scheduler/SchedulerExecutionHistory.vue
@@ -17,11 +17,24 @@
       </div>
       <div class="flex-1 min-w-0">
         <div class="flex items-center justify-between gap-2">
-          <span class="font-medium text-sm truncate">{{ exec.task_name }}</span>
+          <span class="flex items-center gap-2 min-w-0">
+            <span class="font-medium text-sm truncate">{{ exec.task_name }}</span>
+            <span class="badge badge-sm gap-1 shrink-0" :class="originBadgeClass(exec.origin)">
+              <Icon :icon="originIcon(exec.origin)" class="text-xs" />
+              {{ getOriginLabelText(exec.origin) }}
+            </span>
+          </span>
           <span class="text-xs opacity-50 shrink-0">{{ formatDateTimeText(exec.started_at) }}</span>
         </div>
         <div class="text-xs" :class="statusTextClass(exec.status)">
           {{ getStatusLabelText(exec.status) }}
+        </div>
+        <div v-if="exec.scheduled_for" class="text-xs opacity-50">
+          {{ t("settings.scheduler.history.scheduledFor") }}{{ t("common.colon")
+          }}{{ formatDateTimeText(exec.scheduled_for) }}
+        </div>
+        <div v-if="exec.blocker_task_name" class="text-xs text-warning">
+          {{ t("settings.scheduler.history.skippedBy", { name: exec.blocker_task_name }) }}
         </div>
         <div v-if="exec.error_message" class="text-xs text-error opacity-80">
           {{ exec.error_message }}
@@ -34,9 +47,10 @@
 <script setup lang="ts">
 import { useI18n } from "vue-i18n"
 import { Icon } from "@iconify/vue"
-import type { ExecutionStatus, TaskExecution } from "@/types/schedulerModel"
+import type { ExecutionOrigin, ExecutionStatus, TaskExecution } from "@/types/schedulerModel"
 import {
   formatDateTime,
+  getOriginLabel,
   getStatusIcon,
   getStatusLabel,
   getStatusType,
@@ -56,15 +70,41 @@ function getStatusLabelText(status: ExecutionStatus): string {
   return getStatusLabel(t, status)
 }
 
+function getOriginLabelText(origin: ExecutionOrigin): string {
+  return getOriginLabel(t, origin)
+}
+
 function statusIcon(status: ExecutionStatus): string {
   const map: Record<string, string> = {
     "i-mdi-check-circle": "mdi:check-circle",
     "i-mdi-close-circle": "mdi:close-circle",
     "i-mdi-loading": "mdi:loading",
     "i-mdi-pause-circle": "mdi:pause-circle",
+    "i-mdi-account-cancel": "mdi:account-cancel",
+    "i-mdi-calendar-remove": "mdi:calendar-remove",
+    "i-mdi-update": "mdi:update",
+    "i-mdi-clock-alert": "mdi:clock-alert",
     "i-mdi-help-circle": "mdi:help-circle",
   }
   return map[getStatusIcon(status)] || "mdi:help-circle"
+}
+
+function originIcon(origin: ExecutionOrigin): string {
+  const map: Record<string, string> = {
+    manual: "mdi:account",
+    in_app: "mdi:application",
+    native: "mdi:power-sleep",
+  }
+  return map[origin] || "mdi:help-circle"
+}
+
+function originBadgeClass(origin: ExecutionOrigin): string {
+  const map: Record<string, string> = {
+    manual: "badge-info",
+    in_app: "badge-ghost",
+    native: "badge-secondary",
+  }
+  return map[origin] || "badge-ghost"
 }
 
 function statusBgClass(status: ExecutionStatus): string {

--- a/front/src/components/settings/scheduler/SchedulerTaskList.vue
+++ b/front/src/components/settings/scheduler/SchedulerTaskList.vue
@@ -19,12 +19,20 @@
               @change="emit('toggle', task.id, ($event.target as HTMLInputElement).checked)"
             />
             <div class="min-w-0">
-              <div class="font-medium truncate">{{ task.name }}</div>
+              <div class="font-medium truncate">
+                {{ task.name }}
+                <i
+                  v-if="task.wakeup_enabled"
+                  class="i-mdi-power-sleep ml-1 inline-block h-3.5 w-3.5 align-[-2px] opacity-70"
+                  aria-hidden="true"
+                  :title="t('settings.scheduler.list.runsWhenClosed')"
+                />
+              </div>
               <div class="text-xs opacity-60">{{ task.description }}</div>
-              <div class="flex flex-wrap gap-x-3 text-xs opacity-50 mt-1">
+              <div class="flex flex-wrap items-center gap-x-3 text-xs opacity-50 mt-1">
                 <span>
                   {{ t("settings.scheduler.trigger") }}{{ t("common.colon") }}
-                  {{ formatTriggerText(task.trigger_type, task.trigger_config) }}
+                  {{ formatTriggerText(task.trigger_config) }}
                 </span>
                 <span>
                   {{ t("settings.scheduler.nextRun") }}{{ t("common.colon") }}
@@ -51,7 +59,7 @@
 import { useI18n } from "vue-i18n"
 import { Icon } from "@iconify/vue"
 import { formatDateTime, formatTrigger } from "@/utils/scheduler/display"
-import type { ScheduledTask, TriggerConfig, TriggerType } from "@/types/schedulerModel"
+import type { ScheduledTask, TriggerConfig } from "@/types/schedulerModel"
 
 const { tasks } = defineProps<{
   tasks: ScheduledTask[]
@@ -65,8 +73,8 @@ const emit = defineEmits<{
 
 const { t, locale } = useI18n()
 
-function formatTriggerText(triggerType: TriggerType, triggerConfig: TriggerConfig): string {
-  return formatTrigger(t, locale.value, triggerType, triggerConfig)
+function formatTriggerText(triggerConfig: TriggerConfig): string {
+  return formatTrigger(t, locale.value, triggerConfig.type, triggerConfig)
 }
 
 function formatDateTimeText(dateStr?: string): string {

--- a/front/src/components/settings/scheduler/StartConflictDialog.vue
+++ b/front/src/components/settings/scheduler/StartConflictDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <dialog
+    ref="dialogRef"
+    class="modal modal-bottom sm:modal-middle"
+    aria-labelledby="start-conflict-dialog-title"
+    @close="handleClose"
+  >
+    <div class="modal-box w-full max-w-md">
+      <!-- Header -->
+      <header
+        class="border-base-200 flex shrink-0 items-center justify-between gap-3 border-b px-4 py-3 sm:px-5"
+      >
+        <div class="flex min-w-0 items-center gap-2">
+          <Icon icon="mdi:alert-circle" class="text-warning shrink-0 text-xl" aria-hidden="true" />
+          <h3 id="start-conflict-dialog-title" class="truncate text-base font-semibold sm:text-lg">
+            {{ t("settings.scheduler.conflict.title") }}
+          </h3>
+        </div>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm btn-square shrink-0"
+          :title="t('common.cancel')"
+          :aria-label="t('common.cancel')"
+          @click="handleClose"
+        >
+          <Icon icon="mdi:close" class="text-lg" aria-hidden="true" />
+        </button>
+      </header>
+
+      <!-- Body -->
+      <div class="p-4">
+        <div v-if="conflict?.code === 'update_in_progress'" class="alert alert-info">
+          <Icon icon="mdi:information-outline" class="shrink-0" aria-hidden="true" />
+          <span>{{ t("settings.scheduler.conflict.updateInProgress") }}</span>
+        </div>
+        <div v-else-if="conflict" class="alert alert-warning">
+          <Icon icon="mdi:alert-outline" class="shrink-0" aria-hidden="true" />
+          <span>
+            {{ t("settings.scheduler.conflict.busyMessage", { name: conflict.active_task_name }) }}
+          </span>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="modal-action">
+        <button
+          v-if="conflict && conflict.code !== 'update_in_progress'"
+          type="button"
+          class="btn btn-warning"
+          @click="handleStopRestart"
+        >
+          {{ t("settings.scheduler.conflict.stopAndRestart") }}
+        </button>
+        <button type="button" class="btn" @click="handleClose">
+          {{ t("common.cancel") }}
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, useTemplateRef, watch } from "vue"
+import { useI18n } from "vue-i18n"
+import { useRouter } from "vue-router"
+import { Icon } from "@iconify/vue"
+import { useDeviceConnectionStore } from "@/stores/device/deviceConnection"
+
+const { t } = useI18n()
+const router = useRouter()
+const deviceStore = useDeviceConnectionStore()
+
+const dialogRef = useTemplateRef<HTMLDialogElement>("dialogRef")
+const conflict = computed(() => deviceStore.startConflict)
+
+watch(
+  conflict,
+  (value) => {
+    const el = dialogRef.value
+    if (!el) {
+      return
+    }
+    if (value) {
+      if (!el.open) {
+        el.showModal()
+      }
+      return
+    }
+    if (el.open) {
+      el.close()
+    }
+  },
+  { immediate: true },
+)
+
+function handleClose() {
+  deviceStore.clearStartConflict()
+}
+
+async function handleStopRestart() {
+  const success = await deviceStore.stopActiveAndRestart()
+  if (success) {
+    router.push({ name: "logs" })
+  }
+}
+</script>

--- a/front/src/services/api/modules/scheduler.test.ts
+++ b/front/src/services/api/modules/scheduler.test.ts
@@ -51,10 +51,10 @@ describe("scheduler API module", () => {
       const task: ScheduledTaskCreate = {
         name: "new-task",
         enabled: true,
+        wakeup_enabled: false,
         task_list: [],
         task_options: {},
         preTasks: [],
-        trigger_type: "cron",
         trigger_config: { type: "cron", cron: "0 0 * * *" },
       }
       const response = await createSchedulerTask(task)

--- a/front/src/services/api/modules/task.ts
+++ b/front/src/services/api/modules/task.ts
@@ -1,8 +1,11 @@
-import type { TaskExecutionPayload } from "@/types/schedulerModel"
+import type {
+  ManualStartPayload,
+  ManualStartResult,
+  SchedulerApiResponse,
+} from "@/types/schedulerModel"
 import { showGlobalMessage } from "@/services/feedback/message"
-import type { ApiResponse } from "@/services/api/core/types"
 
-export function startTask(payload: TaskExecutionPayload): Promise<boolean> {
+export function startTask(payload: ManualStartPayload): Promise<ManualStartResult> {
   return fetch("/api/start", {
     method: "POST",
     body: JSON.stringify(payload),
@@ -11,17 +14,21 @@ export function startTask(payload: TaskExecutionPayload): Promise<boolean> {
     },
   })
     .then((res) => res.json())
-    .then((data: ApiResponse) => {
-      if (data.status !== "success") {
-        showGlobalMessage("error", data.message || "任务启动失败")
-        return false
+    .then((data: SchedulerApiResponse): ManualStartResult => {
+      if (data.status === "success") {
+        return { accepted: true, runId: data.run_id ?? "" }
       }
-      return true
+      if (data.status === "conflict") {
+        // Conflict is surfaced by the caller via StartConflictDialog, not a toast
+        return { accepted: false, conflict: data.conflict }
+      }
+      showGlobalMessage("error", data.message || "任务启动失败")
+      return { accepted: false, error: data.message || "任务启动失败" }
     })
     .catch((error) => {
       console.error("Failed to start task:", error)
       showGlobalMessage("error", "任务启动失败")
-      return false
+      return { accepted: false, error: "任务启动失败" }
     })
 }
 
@@ -33,7 +40,7 @@ export function stopTask(): Promise<boolean> {
     },
   })
     .then((res) => res.json())
-    .then((data: ApiResponse) => {
+    .then((data: SchedulerApiResponse) => {
       if (data.status === "success") {
         showGlobalMessage("success", "正在中止任务，请稍后")
         return true

--- a/front/src/stores/device/deviceConnection.test.ts
+++ b/front/src/stores/device/deviceConnection.test.ts
@@ -358,6 +358,82 @@ describe("useDeviceConnectionStore", () => {
       expect(showGlobalMessage).not.toHaveBeenCalled()
     })
 
+    describe("stopActiveAndRestart", () => {
+      function primeRunningStore() {
+        const store = useDeviceConnectionStore()
+        const indexStore = useIndexStore()
+        const configStore = useTaskConfigStore()
+        const interfaceStore = useInterfaceStore()
+        store.controllerCapabilities = [adbCapability]
+        store.selectedController = "ADB"
+        store.resource = "res1"
+        store.startConflict = {
+          code: "busy_manual",
+          message: "busy",
+          active_run_id: "run-9",
+          active_task_name: "Other Task",
+          active_origin: "manual",
+        }
+        configStore.configLoaded = true
+        configStore.taskList = [{ id: "task1", name: "Task 1", order: 0, checked: true }]
+        interfaceStore.interface = {
+          task: [{ name: "Task 1", entry: "task1" }],
+        }
+        vi.mocked(api.getDeviceState).mockResolvedValue(lockedAdbState)
+        vi.spyOn(configStore, "buildExecutionPayload").mockReturnValue({
+          task_list: ["task1"],
+          task_options: {},
+          preTasks: [],
+        })
+        indexStore.setTaskRunning(true)
+        return { store, indexStore }
+      }
+
+      it("restarts only after SSE clears TaskRunning", async () => {
+        const { store, indexStore } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+        vi.mocked(api.startTask).mockResolvedValue({ accepted: true, runId: "run-2" })
+
+        const pending = store.stopActiveAndRestart()
+        await nextTick()
+        expect(api.stopTask).toHaveBeenCalled()
+        expect(store.startConflict).toBeNull()
+        // 槽位未释放前不得重试启动
+        expect(api.startTask).not.toHaveBeenCalled()
+
+        indexStore.setTaskRunning(false)
+        await expect(pending).resolves.toBe(true)
+        expect(api.startTask).toHaveBeenCalledTimes(1)
+      })
+
+      it("fails with actionable toast when cleanup exceeds timeout", async () => {
+        vi.useFakeTimers()
+        const { store } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+
+        const pending = store.stopActiveAndRestart()
+        await vi.advanceTimersByTimeAsync(30_000)
+        const result = await pending
+        vi.useRealTimers()
+
+        expect(result).toBe(false)
+        expect(api.startTask).not.toHaveBeenCalled()
+        expect(showGlobalMessage).toHaveBeenCalledWith(
+          "error",
+          "settings.scheduler.conflict.stopTimeout",
+        )
+      })
+
+      it("returns false when stop request fails", async () => {
+        const { store } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(false)
+
+        await expect(store.stopActiveAndRestart()).resolves.toBe(false)
+        expect(api.startTask).not.toHaveBeenCalled()
+        expect(showGlobalMessage).not.toHaveBeenCalled()
+      })
+    })
+
     it("skips connect and resource when already connected", async () => {
       const store = useDeviceConnectionStore()
       const configStore = useTaskConfigStore()

--- a/front/src/stores/device/deviceConnection.test.ts
+++ b/front/src/stores/device/deviceConnection.test.ts
@@ -487,6 +487,38 @@ describe("useDeviceConnectionStore", () => {
         expect(calls).toBeLessThanOrEqual(121)
       })
 
+      it("stops retrying and clears stale conflict when a later attempt fails without conflict", async () => {
+        vi.useFakeTimers()
+        const { store, indexStore } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+        // 复现 greptile 场景：首次重启拿到 busy_manual，下一次因普通错误失败（无 conflict）。
+        // 过期冲突不得驱动重试——应立即停止并清除 startConflict。
+        vi.mocked(api.startTask)
+          .mockResolvedValueOnce({
+            accepted: false,
+            conflict: {
+              code: "busy_manual",
+              message: "busy",
+              active_run_id: "run-9",
+              active_task_name: "Other Task",
+              active_origin: "manual",
+            },
+          })
+          .mockResolvedValueOnce({ accepted: false, error: "任务启动失败" })
+
+        const pending = store.stopActiveAndRestart()
+        await vi.advanceTimersByTimeAsync(0)
+        indexStore.setTaskRunning(false)
+        await vi.advanceTimersByTimeAsync(61_000)
+        const result = await pending
+        vi.useRealTimers()
+
+        expect(result).toBe(false)
+        // 修复前：旧 busy_manual 滞留 → 重试跑满 60s（约 121 次）；修复后：第二次失败即停
+        expect(api.startTask).toHaveBeenCalledTimes(2)
+        expect(store.startConflict).toBeNull()
+      })
+
       it("fails with actionable toast when cleanup exceeds timeout", async () => {
         vi.useFakeTimers()
         const { store } = primeRunningStore()

--- a/front/src/stores/device/deviceConnection.test.ts
+++ b/front/src/stores/device/deviceConnection.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/services/api", () => ({
   postCustomDevice: vi.fn<() => void>(),
   postResource: vi.fn<() => void>(),
   startTask: vi.fn<() => void>(),
+  stopTask: vi.fn<() => void>(),
   getSettings: vi.fn<() => void>(),
   updateSettings: vi.fn<() => void>(),
   getTaskConfig: vi.fn<() => void>(),
@@ -304,6 +305,12 @@ describe("useDeviceConnectionStore", () => {
       const configStore = useTaskConfigStore()
       const interfaceStore = useInterfaceStore()
       const payload = { task_list: ["task1"], task_options: {}, preTasks: [] }
+      const expectedPayload = {
+        ...payload,
+        controller_name: "adb",
+        device: { controller_name: "adb", device_type: "Adb", device_address: "" },
+        resource_name: "res1",
+      }
       store.controllerCapabilities = [adbCapability]
       store.selectedController = "ADB"
       store.resource = "res1"
@@ -315,10 +322,40 @@ describe("useDeviceConnectionStore", () => {
       }
       vi.mocked(api.getDeviceState).mockResolvedValue(lockedAdbState)
       vi.spyOn(configStore, "buildExecutionPayload").mockReturnValue(payload)
-      vi.mocked(api.startTask).mockResolvedValue(true)
+      vi.mocked(api.startTask).mockResolvedValue({ accepted: true, runId: "run-1" })
       const result = await store.StartTask()
       expect(result).toBe(true)
-      expect(api.startTask).toHaveBeenCalledWith(payload)
+      expect(api.startTask).toHaveBeenCalledWith(expectedPayload)
+    })
+
+    it("sets startConflict and returns false on conflict without toast", async () => {
+      const store = useDeviceConnectionStore()
+      const configStore = useTaskConfigStore()
+      const interfaceStore = useInterfaceStore()
+      const payload = { task_list: ["task1"], task_options: {}, preTasks: [] }
+      const conflict = {
+        code: "busy_manual" as const,
+        message: "busy",
+        active_run_id: "run-9",
+        active_task_name: "Other Task",
+        active_origin: "manual" as const,
+      }
+      store.controllerCapabilities = [adbCapability]
+      store.selectedController = "ADB"
+      store.resource = "res1"
+      configStore.configLoaded = true
+      configStore.taskList = [{ id: "task1", name: "Task 1", order: 0, checked: true }]
+
+      interfaceStore.interface = {
+        task: [{ name: "Task 1", entry: "task1" }],
+      }
+      vi.mocked(api.getDeviceState).mockResolvedValue(lockedAdbState)
+      vi.spyOn(configStore, "buildExecutionPayload").mockReturnValue(payload)
+      vi.mocked(api.startTask).mockResolvedValue({ accepted: false, conflict })
+      const result = await store.StartTask()
+      expect(result).toBe(false)
+      expect(store.startConflict).toEqual(conflict)
+      expect(showGlobalMessage).not.toHaveBeenCalled()
     })
 
     it("skips connect and resource when already connected", async () => {
@@ -337,6 +374,12 @@ describe("useDeviceConnectionStore", () => {
       }
       vi.mocked(api.getDeviceState).mockResolvedValue(lockedAdbState)
       vi.spyOn(configStore, "buildExecutionPayload").mockReturnValue(payload)
+      const expectedPayload = {
+        ...payload,
+        controller_name: "adb",
+        device: { controller_name: "adb", device_type: "Adb", device_address: "" },
+        resource_name: "res1",
+      }
       const connectSpy = vi.spyOn(store, "connectDevices").mockResolvedValue({
         success: true,
         message: "ok",
@@ -345,11 +388,12 @@ describe("useDeviceConnectionStore", () => {
         success: true,
         message: "ok",
       })
-      vi.mocked(api.startTask).mockResolvedValue(true)
+      vi.mocked(api.startTask).mockResolvedValue({ accepted: true, runId: "run-1" })
       const result = await store.StartTask()
       expect(result).toBe(true)
       expect(connectSpy).not.toHaveBeenCalled()
       expect(resourceSpy).not.toHaveBeenCalled()
+      expect(api.startTask).toHaveBeenCalledWith(expectedPayload)
     })
   })
 

--- a/front/src/stores/device/deviceConnection.test.ts
+++ b/front/src/stores/device/deviceConnection.test.ts
@@ -406,6 +406,87 @@ describe("useDeviceConnectionStore", () => {
         expect(api.startTask).toHaveBeenCalledTimes(1)
       })
 
+      it("retries when busy_manual conflict arrives after terminal event (slot not yet released)", async () => {
+        vi.useFakeTimers()
+        const { store, indexStore } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+        // 复现：终端事件先于 active_run 清槽 → 首次重启拿到 busy_manual，清槽后重试成功
+        vi.mocked(api.startTask)
+          .mockResolvedValueOnce({
+            accepted: false,
+            conflict: {
+              code: "busy_manual",
+              message: "busy",
+              active_run_id: "run-9",
+              active_task_name: "Other Task",
+              active_origin: "manual",
+            },
+          })
+          .mockResolvedValueOnce({ accepted: true, runId: "run-2" })
+
+        const pending = store.stopActiveAndRestart()
+        await vi.advanceTimersByTimeAsync(0)
+        indexStore.setTaskRunning(false)
+        await vi.advanceTimersByTimeAsync(500)
+        const result = await pending
+        vi.useRealTimers()
+
+        expect(result).toBe(true)
+        expect(api.startTask).toHaveBeenCalledTimes(2)
+        expect(store.startConflict).toBeNull()
+        expect(indexStore.TaskRunning).toBe(true)
+      })
+
+      it("does not retry on busy_scheduled conflict", async () => {
+        const { store, indexStore } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+        const scheduledConflict = {
+          code: "busy_scheduled" as const,
+          message: "busy",
+          active_run_id: "run-10",
+          active_task_name: "Scheduled Task",
+          active_origin: "in_app" as const,
+        }
+        vi.mocked(api.startTask).mockResolvedValue({
+          accepted: false,
+          conflict: scheduledConflict,
+        })
+
+        indexStore.setTaskRunning(false)
+        await expect(store.stopActiveAndRestart()).resolves.toBe(false)
+        expect(api.startTask).toHaveBeenCalledTimes(1)
+        expect(store.startConflict).toEqual(scheduledConflict)
+      })
+
+      it("stops retrying when busy_manual persists past deadline", async () => {
+        vi.useFakeTimers()
+        const { store, indexStore } = primeRunningStore()
+        vi.mocked(api.stopTask).mockResolvedValue(true)
+        vi.mocked(api.startTask).mockResolvedValue({
+          accepted: false,
+          conflict: {
+            code: "busy_manual",
+            message: "busy",
+            active_run_id: "run-9",
+            active_task_name: "Other Task",
+            active_origin: "manual",
+          },
+        })
+
+        const pending = store.stopActiveAndRestart()
+        await vi.advanceTimersByTimeAsync(0)
+        indexStore.setTaskRunning(false)
+        await vi.advanceTimersByTimeAsync(61_000)
+        const result = await pending
+        vi.useRealTimers()
+
+        expect(result).toBe(false)
+        expect(store.startConflict?.code).toBe("busy_manual")
+        const calls = vi.mocked(api.startTask).mock.calls.length
+        expect(calls).toBeGreaterThan(1)
+        expect(calls).toBeLessThanOrEqual(121)
+      })
+
       it("fails with actionable toast when cleanup exceeds timeout", async () => {
         vi.useFakeTimers()
         const { store } = primeRunningStore()

--- a/front/src/stores/device/deviceConnection.ts
+++ b/front/src/stores/device/deviceConnection.ts
@@ -708,7 +708,34 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
         return false
       }
       this.clearStartConflict()
-      await new Promise((resolve) => setTimeout(resolve, 500))
+      // 等待后端释放运行槽位：SSE task.completed/failed 由 dispatcher 置 TaskRunning=false，
+      // 仅在 active_run 清槽之后发出；固定延迟会在清理较慢时撞上 busy_manual 冲突。
+      const indexStore = useIndexStore()
+      const released = await new Promise<boolean>((resolve) => {
+        if (!indexStore.TaskRunning) {
+          resolve(true)
+          return
+        }
+        const timer = window.setTimeout(() => {
+          stopWatch()
+          resolve(false)
+        }, 30_000)
+        const stopWatch = watch(
+          () => indexStore.TaskRunning,
+          (running) => {
+            if (!running) {
+              window.clearTimeout(timer)
+              stopWatch()
+              resolve(true)
+            }
+          },
+        )
+      })
+      if (!released) {
+        const t = i18n.global.t
+        showGlobalMessage("error", t("settings.scheduler.conflict.stopTimeout"))
+        return false
+      }
       return this.StartTask()
     },
 

--- a/front/src/stores/device/deviceConnection.ts
+++ b/front/src/stores/device/deviceConnection.ts
@@ -10,6 +10,7 @@ import {
   postDevices,
   postResource,
   startTask,
+  stopTask,
   type ConnectableDevice,
   type DeviceControllerCapability,
   type PostDeviceResult,
@@ -20,6 +21,7 @@ import { useIndexStore } from "@/stores/panel/session"
 import { useInterfaceStore } from "@/stores/interface/interface"
 import { useSettingsStore } from "@/stores/settings/settings"
 import { useTaskConfigStore } from "@/stores/task-config/taskConfig"
+import type { ManualStartPayload, StartConflict } from "@/types/schedulerModel"
 import type { TaskListItem } from "@/types/taskConfigModel"
 import type { PanelLastConnectedDevice } from "@/types/settingsModel"
 import {
@@ -53,6 +55,7 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
     connectedResourceName: string | null
     deviceStatePollTimer: number | null
     initialized: boolean
+    startConflict: StartConflict | null
     _fetchDevicesRequestId: number
     _fetchResourcesRequestId: number
   } => ({
@@ -69,6 +72,7 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
     connectedResourceName: null,
     deviceStatePollTimer: null,
     initialized: false,
+    startConflict: null,
     _fetchDevicesRequestId: 0,
     _fetchResourcesRequestId: 0,
   }),
@@ -662,12 +666,50 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
         return false
       }
 
-      const payload = configStore.buildExecutionPayload(compatibleTaskIds)
-      const success = await startTask(payload)
-      if (success) {
-        indexStore.setTaskRunning(true)
+      const base = configStore.buildExecutionPayload(compatibleTaskIds)
+      const controllerName = this.selectedControllerName || ""
+      const deviceType = this.selectedControllerCapability?.type || "Adb"
+      const deviceAddress =
+        deviceType === "PlayCover"
+          ? this.playCoverAddress.trim()
+          : buildDeviceAddress(this.selectedDevice)
+
+      const payload: ManualStartPayload = {
+        ...base,
+        controller_name: controllerName,
+        device: {
+          controller_name: controllerName,
+          device_type: deviceType,
+          device_address: deviceAddress,
+        },
+        resource_name: this.resource || "",
       }
-      return success
+
+      const result = await startTask(payload)
+      if (result.accepted) {
+        indexStore.setTaskRunning(true)
+        return true
+      }
+      if (result.conflict) {
+        // No toast here — StartConflictDialog renders from startConflict
+        this.startConflict = result.conflict ?? null
+        return false
+      }
+      return false
+    },
+
+    clearStartConflict() {
+      this.startConflict = null
+    },
+
+    async stopActiveAndRestart(): Promise<boolean> {
+      const stopped = await stopTask()
+      if (!stopped) {
+        return false
+      }
+      this.clearStartConflict()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+      return this.StartTask()
     },
 
     resetConfig() {
@@ -775,6 +817,20 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
 })
 
 // --- Helper functions used by the store ---
+
+/** Backend device_address format per device type (mirrors maa_worker/device_service.py). */
+function buildDeviceAddress(device: ConnectableDevice | null): string {
+  if (!device) {
+    return ""
+  }
+  if (isWin32Device(device)) {
+    return String(device.hWnd)
+  }
+  if (isGamepadDevice(device)) {
+    return `${device.hWnd}|${device.gamepad_type}`
+  }
+  return device.address
+}
 
 function buildStoredLastConnectedDevice(
   deviceInfo: ConnectableDevice,

--- a/front/src/stores/device/deviceConnection.ts
+++ b/front/src/stores/device/deviceConnection.ts
@@ -697,6 +697,9 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
         this.startConflict = result.conflict ?? null
         return false
       }
+      // 非冲突失败同样清掉过期冲突：否则 stopActiveAndRestart 的重试条件
+      // 会拿着旧的 busy_manual 继续空转，对话框也停留在已失效的冲突状态。
+      this.startConflict = null
       return false
     },
 

--- a/front/src/stores/device/deviceConnection.ts
+++ b/front/src/stores/device/deviceConnection.ts
@@ -688,6 +688,8 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
       const result = await startTask(payload)
       if (result.accepted) {
         indexStore.setTaskRunning(true)
+        // 清掉重试路径留下的过期冲突，避免 StartConflictDialog 在运行中弹出
+        this.startConflict = null
         return true
       }
       if (result.conflict) {
@@ -708,8 +710,10 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
         return false
       }
       this.clearStartConflict()
-      // 等待后端释放运行槽位：SSE task.completed/failed 由 dispatcher 置 TaskRunning=false，
-      // 仅在 active_run 清槽之后发出；固定延迟会在清理较慢时撞上 busy_manual 冲突。
+      // 等待后端工作线程结束：SSE task.completed/failed 由 dispatcher 置 TaskRunning=false。
+      // 注意：后端终端事件在 run_process 的 finally 之前发出（task_service.py），即事件
+      // 先于 active_run 清槽（execution.py 的 _complete_run 收尾），因此 TaskRunning=false
+      // 不代表准入槽位已释放，下方必须对 busy_manual 冲突做有限重试。
       const indexStore = useIndexStore()
       const released = await new Promise<boolean>((resolve) => {
         if (!indexStore.TaskRunning) {
@@ -736,7 +740,16 @@ export const useDeviceConnectionStore = defineStore("deviceConnection", {
         showGlobalMessage("error", t("settings.scheduler.conflict.stopTimeout"))
         return false
       }
-      return this.StartTask()
+      // active_run 清槽晚于终端事件（落库在 asyncio.to_thread 中），轮询重试直至准入成功；
+      // 仅对 busy_manual 重试——busy_scheduled/update_in_progress 是真实占用，立即返回冲突。
+      // 上限 60s：后端收尾含 sqlite 落库，正常在数百毫秒内完成。
+      const deadline = Date.now() + 60_000
+      let restarted = await this.StartTask()
+      while (!restarted && this.startConflict?.code === "busy_manual" && Date.now() < deadline) {
+        await new Promise((resolve) => window.setTimeout(resolve, 500))
+        restarted = await this.StartTask()
+      }
+      return restarted
     },
 
     resetConfig() {

--- a/front/src/stores/scheduler/scheduler.test.ts
+++ b/front/src/stores/scheduler/scheduler.test.ts
@@ -22,7 +22,7 @@ const mockTask = (id: string, enabled: boolean): ScheduledTask => ({
   task_list: [],
   task_options: {},
   preTasks: [],
-  trigger_type: "cron",
+  wakeup_enabled: false,
   trigger_config: { type: "cron", cron: "* * * * *" },
   created_at: "2024-01-01T00:00:00Z",
   updated_at: "2024-01-01T00:00:00Z",
@@ -83,7 +83,7 @@ describe("useSchedulerStore", () => {
   })
 
   describe("createTask", () => {
-    it("pushes task and returns true on success", async () => {
+    it("pushes task and returns the created task on success", async () => {
       const created = mockTask("new", true)
       vi.mocked(api.createSchedulerTask).mockResolvedValue({
         status: "success",
@@ -93,17 +93,17 @@ describe("useSchedulerStore", () => {
       const result = await store.createTask({
         name: "new",
         enabled: true,
+        wakeup_enabled: false,
         task_list: [],
         task_options: {},
         preTasks: [],
-        trigger_type: "cron",
         trigger_config: { type: "cron", cron: "* * * * *" },
       })
-      expect(result).toBe(true)
+      expect(result).toEqual(created)
       expect(store.tasks).toContainEqual(created)
     })
 
-    it("sets error and returns false on failure", async () => {
+    it("sets error and returns null on failure", async () => {
       vi.mocked(api.createSchedulerTask).mockResolvedValue({
         status: "failed",
         message: "create failed",
@@ -112,13 +112,13 @@ describe("useSchedulerStore", () => {
       const result = await store.createTask({
         name: "new",
         enabled: true,
+        wakeup_enabled: false,
         task_list: [],
         task_options: {},
         preTasks: [],
-        trigger_type: "cron",
         trigger_config: { type: "cron", cron: "* * * * *" },
       })
-      expect(result).toBe(false)
+      expect(result).toBeNull()
       expect(store.error).toBe("create failed")
     })
   })
@@ -203,6 +203,10 @@ describe("useSchedulerStore", () => {
           id: "e1",
           task_id: "1",
           task_name: "task-1",
+          origin: "in_app",
+          occurrence_id: null,
+          scheduled_for: null,
+          blocker_task_name: null,
           started_at: "2024-01-01T00:00:00Z",
           status: "success",
         },

--- a/front/src/stores/scheduler/scheduler.ts
+++ b/front/src/stores/scheduler/scheduler.ts
@@ -47,7 +47,7 @@ export const useSchedulerStore = defineStore("scheduler", () => {
     loading.value = false
   }
 
-  async function createTask(task: ScheduledTaskCreate) {
+  async function createTask(task: ScheduledTaskCreate): Promise<ScheduledTask | null> {
     loading.value = true
     error.value = null
     const [response, err] = await tryCatch(() => createSchedulerTask(task))
@@ -55,16 +55,16 @@ export const useSchedulerStore = defineStore("scheduler", () => {
       error.value = "网络错误，请稍后重试"
       console.error("Failed to create task:", err)
       loading.value = false
-      return false
+      return null
     }
     if (response.status === "success" && response.task) {
       tasks.value.push(response.task)
       loading.value = false
-      return true
+      return response.task
     }
     error.value = response.message || "创建任务失败"
     loading.value = false
-    return false
+    return null
   }
 
   async function updateTask(taskId: string, taskUpdate: ScheduledTaskUpdate) {

--- a/front/src/types/schedulerModel.ts
+++ b/front/src/types/schedulerModel.ts
@@ -1,8 +1,18 @@
 import type { PreTaskCommand } from "@/types/taskConfigModel"
 
-export type TriggerType = "cron" | "date" | "interval"
+export type TriggerType = TriggerConfig["type"]
 
-export type ExecutionStatus = "running" | "success" | "failed" | "stopped"
+export type ExecutionOrigin = "manual" | "in_app" | "native"
+
+export type ExecutionStatus =
+  | "running"
+  | "success"
+  | "failed"
+  | "stopped"
+  | "skipped_busy_manual"
+  | "skipped_busy_scheduled"
+  | "skipped_update_in_progress"
+  | "missed_deadline"
 
 export interface CronTriggerConfig {
   type: "cron"
@@ -43,12 +53,30 @@ export interface ScheduledTaskDeviceConfig {
   device_address: string
 }
 
+export interface StartConflict {
+  code: "busy_manual" | "busy_scheduled" | "update_in_progress"
+  message: string
+  active_run_id: string
+  active_task_name: string
+  active_origin: ExecutionOrigin
+}
+
+export interface ManualStartPayload extends TaskExecutionPayload {
+  controller_name: string
+  device: ScheduledTaskDeviceConfig
+  resource_name: string
+}
+
+export type ManualStartResult =
+  | { accepted: true; runId: string }
+  | { accepted: false; conflict?: StartConflict; error?: string }
+
 export interface ScheduledTask extends TaskExecutionPayload {
   id: string
   name: string
   description?: string
   enabled: boolean
-  trigger_type: TriggerType
+  wakeup_enabled: boolean
   trigger_config: TriggerConfig
   controller_name?: string | null
   device?: ScheduledTaskDeviceConfig | null
@@ -62,7 +90,7 @@ export interface ScheduledTaskCreate extends TaskExecutionPayload {
   name: string
   description?: string
   enabled: boolean
-  trigger_type: TriggerType
+  wakeup_enabled: boolean
   trigger_config: TriggerConfig
   controller_name?: string | null
   device?: ScheduledTaskDeviceConfig | null
@@ -73,7 +101,7 @@ export interface ScheduledTaskUpdate {
   name?: string
   description?: string
   enabled?: boolean
-  trigger_type?: TriggerType
+  wakeup_enabled?: boolean
   trigger_config?: TriggerConfig
   controller_name?: string | null
   device?: ScheduledTaskDeviceConfig | null
@@ -85,17 +113,24 @@ export interface ScheduledTaskUpdate {
 
 export interface TaskExecution {
   id: string
-  task_id: string
+  task_id: string | null
   task_name: string
+  origin: ExecutionOrigin
+  occurrence_id: string | null
+  scheduled_for: string | null
+  blocker_task_name: string | null
   started_at: string // ISO 8601 datetime string
-  finished_at?: string // ISO 8601 datetime string
+  finished_at?: string | null // ISO 8601 datetime string
   status: ExecutionStatus
-  error_message?: string
+  error_message?: string | null
 }
 
 export interface SchedulerApiResponse {
-  status: "success" | "failed"
+  status: "success" | "failed" | "conflict"
   message?: string
+  run_id?: string
+  conflict?: StartConflict
+  skip_status?: string | null
   tasks?: ScheduledTask[]
   task?: ScheduledTask
   executions?: TaskExecution[]

--- a/front/src/utils/scheduler/cronNative.test.ts
+++ b/front/src/utils/scheduler/cronNative.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { checkCronNativeEligibility } from "@/utils/scheduler/cronNative"
+
+describe("checkCronNativeEligibility", () => {
+  describe("accepts", () => {
+    it("daily cron", () => {
+      expect(checkCronNativeEligibility("0 9 * * *")).toBe(true)
+    })
+
+    it("weekly cron with dow 0", () => {
+      expect(checkCronNativeEligibility("30 14 * * 0")).toBe(true)
+    })
+
+    it("weekly cron with dow 7", () => {
+      expect(checkCronNativeEligibility("30 14 * * 7")).toBe(true)
+    })
+
+    it("hourly cron with concrete minute", () => {
+      expect(checkCronNativeEligibility("5 * * * *")).toBe(true)
+    })
+
+    it("monthly cron on day 15", () => {
+      expect(checkCronNativeEligibility("0 9 15 * *")).toBe(true)
+    })
+
+    it("month + day cron", () => {
+      expect(checkCronNativeEligibility("0 9 15 3 *")).toBe(true)
+    })
+  })
+
+  describe("rejects", () => {
+    it("wildcard minute", () => {
+      expect(checkCronNativeEligibility("* * * * *")).toBe(false)
+    })
+
+    it("hour wildcard with restricted day", () => {
+      expect(checkCronNativeEligibility("0 * 15 * *")).toBe(false)
+    })
+
+    it("day and dow both restricted", () => {
+      expect(checkCronNativeEligibility("0 9 15 * 1")).toBe(false)
+    })
+
+    it("month restricted without day", () => {
+      expect(checkCronNativeEligibility("0 9 * 3 *")).toBe(false)
+    })
+
+    it("list in minute", () => {
+      expect(checkCronNativeEligibility("0,30 9 * * *")).toBe(false)
+    })
+
+    it("step in minute", () => {
+      expect(checkCronNativeEligibility("*/5 9 * * *")).toBe(false)
+    })
+
+    it("range in day", () => {
+      expect(checkCronNativeEligibility("0 9 1-5 * *")).toBe(false)
+    })
+
+    it("wrong field count", () => {
+      expect(checkCronNativeEligibility("0 9 * *")).toBe(false)
+      expect(checkCronNativeEligibility("0 9 * * * *")).toBe(false)
+    })
+
+    it("empty string", () => {
+      expect(checkCronNativeEligibility("")).toBe(false)
+    })
+  })
+})

--- a/front/src/utils/scheduler/cronNative.test.ts
+++ b/front/src/utils/scheduler/cronNative.test.ts
@@ -65,5 +65,14 @@ describe("checkCronNativeEligibility", () => {
     it("empty string", () => {
       expect(checkCronNativeEligibility("")).toBe(false)
     })
+
+    it("out-of-range numeric fields", () => {
+      expect(checkCronNativeEligibility("99 9 * * *")).toBe(false)
+      expect(checkCronNativeEligibility("0 24 * * *")).toBe(false)
+      expect(checkCronNativeEligibility("0 9 0 * *")).toBe(false)
+      expect(checkCronNativeEligibility("0 9 32 * *")).toBe(false)
+      expect(checkCronNativeEligibility("0 9 15 13 *")).toBe(false)
+      expect(checkCronNativeEligibility("99 99 99 99 *")).toBe(false)
+    })
   })
 })

--- a/front/src/utils/scheduler/cronNative.ts
+++ b/front/src/utils/scheduler/cronNative.ts
@@ -1,0 +1,30 @@
+/**
+ * cron 原生唤醒资格预检。
+ *
+ * 后端（services/native_cron.py 的 parse_native_cron）为权威，前端仅做可用性预检：
+ * 不合格时后端会在创建/更新时返回 400，这里只负责提前禁用唤醒开关。
+ *
+ * 规则（与后端一致）：
+ * - 必须为 5 个字段：minute hour day month dow
+ * - 每个字段只允许单个具体整数或 `*`（不支持列表/范围/步进）
+ * - minute 必须为具体分钟（非 `*`），保证有确定的唤醒时刻
+ * - dow 取值范围 0-7（7 表示周日，与 Unix cron 一致）
+ * - day 与 dow 不得同时受限（两者都非 `*`）
+ * - hour 为 `*` 时，day/month/dow 必须全为 `*`
+ * - month 受限（非 `*`）时，day 必须受限
+ */
+export function checkCronNativeEligibility(cron: string): boolean {
+  const fields = cron.trim().split(/\s+/)
+  if (fields.length !== 5) return false
+
+  const [minute, hour, day, month, dow] = fields
+
+  if (fields.some((field) => field !== "*" && !/^\d+$/.test(field))) return false
+  if (minute === "*") return false
+  if (dow !== "*" && (Number(dow) < 0 || Number(dow) > 7)) return false
+  if (day !== "*" && dow !== "*") return false
+  if (hour === "*" && (day !== "*" || month !== "*" || dow !== "*")) return false
+  if (month !== "*" && day === "*") return false
+
+  return true
+}

--- a/front/src/utils/scheduler/cronNative.ts
+++ b/front/src/utils/scheduler/cronNative.ts
@@ -7,6 +7,7 @@
  * 规则（与后端一致）：
  * - 必须为 5 个字段：minute hour day month dow
  * - 每个字段只允许单个具体整数或 `*`（不支持列表/范围/步进）
+ * - 数值范围：minute 0-59、hour 0-23、day 1-31、month 1-12
  * - minute 必须为具体分钟（非 `*`），保证有确定的唤醒时刻
  * - dow 取值范围 0-7（7 表示周日，与 Unix cron 一致）
  * - day 与 dow 不得同时受限（两者都非 `*`）
@@ -20,6 +21,11 @@ export function checkCronNativeEligibility(cron: string): boolean {
   const [minute, hour, day, month, dow] = fields
 
   if (fields.some((field) => field !== "*" && !/^\d+$/.test(field))) return false
+  // 数值字段范围与后端 parse_native_cron 的 _FIELD_RANGES 保持一致
+  if (minute !== "*" && (Number(minute) < 0 || Number(minute) > 59)) return false
+  if (hour !== "*" && (Number(hour) < 0 || Number(hour) > 23)) return false
+  if (day !== "*" && (Number(day) < 1 || Number(day) > 31)) return false
+  if (month !== "*" && (Number(month) < 1 || Number(month) > 12)) return false
   if (minute === "*") return false
   if (dow !== "*" && (Number(dow) < 0 || Number(dow) > 7)) return false
   if (day !== "*" && dow !== "*") return false

--- a/front/src/utils/scheduler/display.test.ts
+++ b/front/src/utils/scheduler/display.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   formatTrigger,
   formatDateTime,
+  getOriginLabel,
   getStatusType,
   getStatusIcon,
   getStatusLabel,
@@ -9,6 +10,7 @@ import {
 import type {
   CronTriggerConfig,
   DateTriggerConfig,
+  ExecutionOrigin,
   ExecutionStatus,
   IntervalTriggerConfig,
 } from "@/types/schedulerModel"
@@ -116,6 +118,10 @@ describe("getStatusType", () => {
     ["failed", "error"],
     ["running", "info"],
     ["stopped", "warning"],
+    ["skipped_busy_manual", "warning"],
+    ["skipped_busy_scheduled", "warning"],
+    ["skipped_update_in_progress", "warning"],
+    ["missed_deadline", "warning"],
   ] satisfies [ExecutionStatus, ReturnType<typeof getStatusType>][])(
     "maps %s to %s",
     (status, expected) => {
@@ -135,6 +141,10 @@ describe("getStatusIcon", () => {
     ["failed", "i-mdi-close-circle"],
     ["running", "i-mdi-loading"],
     ["stopped", "i-mdi-pause-circle"],
+    ["skipped_busy_manual", "i-mdi-account-cancel"],
+    ["skipped_busy_scheduled", "i-mdi-calendar-remove"],
+    ["skipped_update_in_progress", "i-mdi-update"],
+    ["missed_deadline", "i-mdi-clock-alert"],
   ] satisfies [ExecutionStatus, string][])("maps %s to %s", (status, expected) => {
     expect(getStatusIcon(status)).toBe(expected)
   })
@@ -153,6 +163,10 @@ describe("getStatusLabel", () => {
     ["failed", "settings.scheduler.status.failed"],
     ["running", "settings.scheduler.status.running"],
     ["stopped", "settings.scheduler.status.stopped"],
+    ["skipped_busy_manual", "settings.scheduler.status.skippedBusyManual"],
+    ["skipped_busy_scheduled", "settings.scheduler.status.skippedBusyScheduled"],
+    ["skipped_update_in_progress", "settings.scheduler.status.skippedUpdateInProgress"],
+    ["missed_deadline", "settings.scheduler.status.missedDeadline"],
   ] satisfies [ExecutionStatus, string][])("maps %s to %s", (status, expected) => {
     expect(getStatusLabel(t, status)).toBe(expected)
   })
@@ -160,5 +174,22 @@ describe("getStatusLabel", () => {
   it("returns unknown for unknown status", () => {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     expect(getStatusLabel(t, "unknown" as ExecutionStatus)).toBe("common.unknown")
+  })
+})
+
+describe("getOriginLabel", () => {
+  const t = vi.fn<(key: string) => string>((key: string) => key)
+
+  it.each([
+    ["manual", "settings.scheduler.origin.manual"],
+    ["in_app", "settings.scheduler.origin.inApp"],
+    ["native", "settings.scheduler.origin.native"],
+  ] satisfies [ExecutionOrigin, string][])("maps %s to %s", (origin, expected) => {
+    expect(getOriginLabel(t, origin)).toBe(expected)
+  })
+
+  it("returns unknown for unknown origin", () => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    expect(getOriginLabel(t, "unknown" as ExecutionOrigin)).toBe("common.unknown")
   })
 })

--- a/front/src/utils/scheduler/display.ts
+++ b/front/src/utils/scheduler/display.ts
@@ -1,4 +1,9 @@
-import type { ExecutionStatus, TriggerConfig, TriggerType } from "@/types/schedulerModel"
+import type {
+  ExecutionOrigin,
+  ExecutionStatus,
+  TriggerConfig,
+  TriggerType,
+} from "@/types/schedulerModel"
 
 function formatCronTrigger(t: (key: string) => string, triggerConfig: TriggerConfig): string {
   if (triggerConfig.type !== "cron") return t("common.unknown")
@@ -76,6 +81,11 @@ export function getStatusType(
       return "info"
     case "stopped":
       return "warning"
+    case "skipped_busy_manual":
+    case "skipped_busy_scheduled":
+    case "skipped_update_in_progress":
+    case "missed_deadline":
+      return "warning"
     default:
       return "default"
   }
@@ -91,6 +101,14 @@ export function getStatusIcon(status: ExecutionStatus): string {
       return "i-mdi-loading"
     case "stopped":
       return "i-mdi-pause-circle"
+    case "skipped_busy_manual":
+      return "i-mdi-account-cancel"
+    case "skipped_busy_scheduled":
+      return "i-mdi-calendar-remove"
+    case "skipped_update_in_progress":
+      return "i-mdi-update"
+    case "missed_deadline":
+      return "i-mdi-clock-alert"
     default:
       return "i-mdi-help-circle"
   }
@@ -106,6 +124,27 @@ export function getStatusLabel(t: (key: string) => string, status: ExecutionStat
       return t("settings.scheduler.status.running")
     case "stopped":
       return t("settings.scheduler.status.stopped")
+    case "skipped_busy_manual":
+      return t("settings.scheduler.status.skippedBusyManual")
+    case "skipped_busy_scheduled":
+      return t("settings.scheduler.status.skippedBusyScheduled")
+    case "skipped_update_in_progress":
+      return t("settings.scheduler.status.skippedUpdateInProgress")
+    case "missed_deadline":
+      return t("settings.scheduler.status.missedDeadline")
+    default:
+      return t("common.unknown")
+  }
+}
+
+export function getOriginLabel(t: (key: string) => string, origin: ExecutionOrigin): string {
+  switch (origin) {
+    case "manual":
+      return t("settings.scheduler.origin.manual")
+    case "in_app":
+      return t("settings.scheduler.origin.inApp")
+    case "native":
+      return t("settings.scheduler.origin.native")
     default:
       return t("common.unknown")
   }

--- a/front/src/views/RoutinesView.vue
+++ b/front/src/views/RoutinesView.vue
@@ -26,7 +26,7 @@
             :class="{ 'tab-active': activeTab === 'history' }"
             @click="activeTab = 'history'"
           >
-            {{ t("settings.scheduler.history") }}
+            {{ t("settings.scheduler.historyTitle") }}
           </a>
         </div>
 

--- a/front/src/views/TasksView.vue
+++ b/front/src/views/TasksView.vue
@@ -56,6 +56,8 @@
     <!-- Mobile task settings drawer -->
     <TaskSettingsDrawer v-if="isMobile" />
   </div>
+
+  <StartConflictDialog />
 </template>
 
 <script setup lang="ts">
@@ -67,6 +69,7 @@ import PanelTaskColumn from "@/components/panel/PanelTaskColumn.vue"
 import TaskSettingsDrawer from "@/components/panel/task/TaskSettingsDrawer.vue"
 import PreTaskList from "@/components/panel/task/PreTaskList.vue"
 import TaskSelectList from "@/components/panel/task/TaskSelectList.vue"
+import StartConflictDialog from "@/components/settings/scheduler/StartConflictDialog.vue"
 import { stopTask } from "@/services/api"
 import { useIndexStore, useTaskConfigStore, useDeviceConnectionStore } from "@/stores"
 import type { TaskListItem } from "@/types/taskConfigModel"


### PR DESCRIPTION
## 变更
镜像后端 PR #26 契约的前端落地。基于 `feat/system-schedule-backend`。

**类型与 API**
- `types/schedulerModel.ts`：`wakeup_enabled`、`origin`、8 值 `ExecutionStatus`、`ManualStartPayload`/`StartConflict`/`ManualStartResult`；**移除 `trigger_type`**（改用 `trigger_config.type`）
- `services/api/modules/task.ts`：`startTask` 返回 `ManualStartResult` 三态；冲突路径不 toast（交给对话）
- `utils/scheduler/cronNative.ts`：原生 cron 资格前端预检（后端为权威，400 返中文原因）

**组件**
- `SchedulerTaskDialog`：`trigger_config.type` 判别触发器；cron 专属"关闭后仍运行"开关（不合格 cron 禁用 + 警告）；`wakeupEnabled` 单 ref 直读
- `SchedulerTaskList`：唤醒徽标（`mdi:power-sleep` + tooltip）
- `SchedulerExecutionHistory`：来源徽标（manual/in_app/native 三色）+ `blocker_task_name` 提示 + `scheduled_for` 行
- `StartConflictDialog`（新）：手动启动冲突对话，"停止并重启"→`stopActiveAndRestart()`→跳日志页；挂载于 `TasksView`

**Store**
- `deviceConnection.StartTask` 构造完整 `ManualStartPayload`；冲突置 `startConflict` 不 toast
- `scheduler.createTask` 返回创建的任务；`updateTask` 响应替换本地行；`toggleTask` 本地改 `enabled`

**i18n**：双语言同步；`settings.scheduler.history` 字符串让位嵌套对象改名 `historyTitle`（仅 RoutinesView 一处引用，已同步）。

## 验证
- `pnpm exec tsc --noEmit` 0 错误；`pnpm lint` 0 错误（2 个 complexity 警告：StartTask/cronNative，均为不可约分支）；`pnpm test:run` **306 passed**；`pnpm build` 成功
- 浏览器实机：/routines 新建 cron 任务可见唤醒开关（`* * * * *` → 禁用 + "不支持系统级唤醒"警告；`0 9 * * *` → 可开）；保存后列表出现唤醒徽标 + `schtasks /Query` 确认 OS 注册（次日 9:00）；执行历史显示"系统"来源徽标；置 `startConflict` 后冲突对话弹出（"停止并重启"按钮在）

## 关联
依赖 #26（后端契约）。

## Summary by Sourcery

为系统级的计划任务唤醒、具冲突感知的手动任务启动，以及更丰富的执行历史元数据添加前端支持。

New Features:
- 允许为基于 cron 的计划任务配置“系统关闭时唤醒”选项，并在前端进行适用性检查与提供相应的 UI 控件。
- 在调度器执行历史中显示来源徽标、计划时间和阻塞信息，并在任务列表中显示唤醒指示。
- 引入手动启动冲突对话框，允许用户停止正在运行的任务并重新启动，然后跳转到日志视图。

Enhancements:
- 扩展调度器模型、API 集成和展示辅助函数，以支持新的执行来源、跳过状态以及具冲突感知的启动响应。
- 更新设备连接逻辑，以发送完整的手动启动负载、跟踪启动冲突，并实现带有重试和超时处理的“停止并重新启动”流程。
- 优化调度器任务对话框的用户体验，包括响应式尺寸、改进的触发处理、可创建的设备选择，以及限制任务列表高度。
- 确保路由切换时完全重新挂载组件，以防止在切换过程中出现多根视图泄漏。

Tests:
- 添加针对 cron 原生适用性规则、调度器显示来源/状态映射，以及设备连接冲突重启行为的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add frontend support for system-level scheduled task wake, conflict-aware manual task start, and richer execution history metadata.

New Features:
- Allow configuring a system wake-on-close option for cron-based scheduled tasks with frontend eligibility checks and UI controls.
- Display origin badges, scheduled time, and blocker information in scheduler execution history and wakeup indicators in the task list.
- Introduce a manual start conflict dialog that lets users stop the active run and restart, then navigates to logs.

Enhancements:
- Extend scheduler models, API integration, and display helpers to support new execution origins, skip statuses, and conflict-aware start responses.
- Update device connection logic to send full manual start payloads, track start conflicts, and implement a stop-and-restart flow with retry and timeout handling.
- Refine scheduler task dialog UX with responsive sizing, improved trigger handling, creatable device selection, and capped task list height.
- Ensure route transitions fully remount components to prevent multi-root view leakage under transitions.

Tests:
- Add unit tests for cron native eligibility rules, scheduler display origin/status mappings, and device connection conflict restart behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为系统级的计划任务唤醒、具冲突感知的手动任务启动，以及更丰富的执行历史元数据添加前端支持。

New Features:
- 允许为基于 cron 的计划任务配置“系统关闭时唤醒”选项，并在前端进行适用性检查与提供相应的 UI 控件。
- 在调度器执行历史中显示来源徽标、计划时间和阻塞信息，并在任务列表中显示唤醒指示。
- 引入手动启动冲突对话框，允许用户停止正在运行的任务并重新启动，然后跳转到日志视图。

Enhancements:
- 扩展调度器模型、API 集成和展示辅助函数，以支持新的执行来源、跳过状态以及具冲突感知的启动响应。
- 更新设备连接逻辑，以发送完整的手动启动负载、跟踪启动冲突，并实现带有重试和超时处理的“停止并重新启动”流程。
- 优化调度器任务对话框的用户体验，包括响应式尺寸、改进的触发处理、可创建的设备选择，以及限制任务列表高度。
- 确保路由切换时完全重新挂载组件，以防止在切换过程中出现多根视图泄漏。

Tests:
- 添加针对 cron 原生适用性规则、调度器显示来源/状态映射，以及设备连接冲突重启行为的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add frontend support for system-level scheduled task wake, conflict-aware manual task start, and richer execution history metadata.

New Features:
- Allow configuring a system wake-on-close option for cron-based scheduled tasks with frontend eligibility checks and UI controls.
- Display origin badges, scheduled time, and blocker information in scheduler execution history and wakeup indicators in the task list.
- Introduce a manual start conflict dialog that lets users stop the active run and restart, then navigates to logs.

Enhancements:
- Extend scheduler models, API integration, and display helpers to support new execution origins, skip statuses, and conflict-aware start responses.
- Update device connection logic to send full manual start payloads, track start conflicts, and implement a stop-and-restart flow with retry and timeout handling.
- Refine scheduler task dialog UX with responsive sizing, improved trigger handling, creatable device selection, and capped task list height.
- Ensure route transitions fully remount components to prevent multi-root view leakage under transitions.

Tests:
- Add unit tests for cron native eligibility rules, scheduler display origin/status mappings, and device connection conflict restart behavior.

</details>

</details>