### PR TITLE
feat: 实现PI v2.8.0

### DIFF
--- a/front/src/app/i18n/messages/en-US.json
+++ b/front/src/app/i18n/messages/en-US.json
@@ -274,7 +274,9 @@
     }
   },
   "option": {
-    "hotkeyCapturing": "Press shortcut keys..."
+    "hotkeyCapturing": "Press shortcut keys...",
+    "hotkeyMetaUnsupported": "Meta, Command, and Win shortcuts are not supported",
+    "hotkeyTooManyModifiers": "Shortcuts support at most two modifier keys"
   },
   "panel": {
     "device": "Connect Device",

--- a/front/src/app/i18n/messages/en-US.json
+++ b/front/src/app/i18n/messages/en-US.json
@@ -40,6 +40,7 @@
     "networkError": "Network error, please try again later",
     "anchor": {
       "update": "Update Settings",
+      "taskSettings": "Task Settings",
       "runtime": "Runtime Settings",
       "scheduler": "Scheduler",
       "ui": "UI Settings",
@@ -79,6 +80,9 @@
         "mirrorchyan": "MirrorChyan",
         "github": "GitHub"
       }
+    },
+    "taskSettings": {
+      "empty": "No configurable options"
     },
     "runtime": {
       "title": "Runtime Settings",
@@ -268,6 +272,9 @@
       "resetSuccess": "Settings have been reset to default",
       "githubIssues": "GitHub Issues"
     }
+  },
+  "option": {
+    "hotkeyCapturing": "Press shortcut keys..."
   },
   "panel": {
     "device": "Connect Device",

--- a/front/src/app/i18n/messages/zh-CN.json
+++ b/front/src/app/i18n/messages/zh-CN.json
@@ -40,6 +40,7 @@
     "networkError": "网络错误，请稍后重试",
     "anchor": {
       "update": "更新设置",
+      "taskSettings": "任务设置",
       "runtime": "运行设置",
       "scheduler": "定时任务",
       "ui": "界面设置",
@@ -79,6 +80,9 @@
         "mirrorchyan": "Mirror酱",
         "github": "GitHub"
       }
+    },
+    "taskSettings": {
+      "empty": "暂无可配置项"
     },
     "runtime": {
       "title": "运行设置",
@@ -268,6 +272,9 @@
       "resetSuccess": "设置已重置为默认值",
       "githubIssues": "GitHub Issues"
     }
+  },
+  "option": {
+    "hotkeyCapturing": "请按下快捷键…"
   },
   "panel": {
     "device": "设备连接",

--- a/front/src/app/i18n/messages/zh-CN.json
+++ b/front/src/app/i18n/messages/zh-CN.json
@@ -274,7 +274,9 @@
     }
   },
   "option": {
-    "hotkeyCapturing": "请按下快捷键…"
+    "hotkeyCapturing": "请按下快捷键…",
+    "hotkeyMetaUnsupported": "不支持 Meta、Command 或 Win 组合键",
+    "hotkeyTooManyModifiers": "快捷键最多支持两个修饰键"
   },
   "panel": {
     "device": "设备连接",

--- a/front/src/components/common/controls/OptionCheckboxControl.vue
+++ b/front/src/components/common/controls/OptionCheckboxControl.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="flex flex-wrap gap-3">
+    <NCheckbox
+      v-for="checkbox in option.cases"
+      :key="checkbox.name"
+      :checked="normalizedValue.includes(checkbox.name)"
+      @update:checked="handleCheckboxChange(checkbox.name, $event)"
+    >
+      {{ resolveCaseLabel(checkbox.label, checkbox.name) }}
+    </NCheckbox>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useI18n } from "vue-i18n"
+import { useInterfaceStore } from "@/stores"
+import type { CheckboxOption } from "@/types/interfaceModel"
+import { resolveInterfaceText } from "@/utils/interface/content"
+
+const { option, value } = defineProps<{
+  option: CheckboxOption
+  value: string[]
+}>()
+
+const emit = defineEmits<{
+  (event: "update:value", value: string[]): void
+}>()
+
+const { locale } = useI18n()
+const interfaceStore = useInterfaceStore()
+
+const normalizedValue = computed(() => {
+  const selected = new Set(value)
+  return option.cases.map((item) => item.name).filter((name) => selected.has(name))
+})
+
+function resolveCaseLabel(label: string | undefined, fallback: string): string {
+  return resolveInterfaceText(interfaceStore.interface, locale.value, label, fallback)
+}
+
+function handleCheckboxChange(checkboxName: string, checked: boolean): void {
+  const selected = new Set(normalizedValue.value)
+  if (checked) {
+    selected.add(checkboxName)
+  }
+  if (!checked) {
+    selected.delete(checkboxName)
+  }
+  emit(
+    "update:value",
+    option.cases.map((item) => item.name).filter((name) => selected.has(name)),
+  )
+}
+</script>

--- a/front/src/components/common/controls/OptionHotkeyControl.vue
+++ b/front/src/components/common/controls/OptionHotkeyControl.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="flex w-full max-w-sm flex-col gap-2">
+    <div v-for="hotkey in option.hotkeys" :key="hotkey.name" class="flex flex-col gap-1">
+      <span class="text-xs opacity-60">{{ resolveHotkeyLabel(hotkey.label, hotkey.name) }}</span>
+      <NInput
+        size="small"
+        readonly
+        :value="capturingName === hotkey.name ? '' : getHotkeyValue(hotkey.name)"
+        :placeholder="capturingName === hotkey.name ? t('option.hotkeyCapturing') : undefined"
+        @focus="capturingName = hotkey.name"
+        @blur="handleBlur(hotkey.name)"
+        @keydown="handleKeydown(hotkey.name, $event)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue"
+import { useI18n } from "vue-i18n"
+import { useInterfaceStore } from "@/stores"
+import type { HotkeyOption } from "@/types/interfaceModel"
+import { buildHotkeyCombo } from "@/utils/hotkey"
+import { resolveInterfaceText } from "@/utils/interface/content"
+
+const { option, value } = defineProps<{
+  option: HotkeyOption
+  value: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  (event: "update:value", value: Record<string, string>): void
+}>()
+
+const { locale, t } = useI18n()
+const interfaceStore = useInterfaceStore()
+const capturingName = ref<string | null>(null)
+
+function resolveHotkeyLabel(label: string | undefined, fallback: string): string {
+  return resolveInterfaceText(interfaceStore.interface, locale.value, label, fallback)
+}
+
+function getHotkeyValue(name: string): string {
+  return value[name] ?? ""
+}
+
+function handleBlur(name: string): void {
+  if (capturingName.value === name) {
+    capturingName.value = null
+  }
+}
+
+function handleKeydown(name: string, event: KeyboardEvent): void {
+  event.preventDefault()
+  const combo = buildHotkeyCombo(event)
+  if (!combo) return
+  emit("update:value", { ...value, [name]: combo })
+}
+</script>

--- a/front/src/components/common/controls/OptionHotkeyControl.vue
+++ b/front/src/components/common/controls/OptionHotkeyControl.vue
@@ -7,10 +7,14 @@
         readonly
         :value="capturingName === hotkey.name ? '' : getHotkeyValue(hotkey.name)"
         :placeholder="capturingName === hotkey.name ? t('option.hotkeyCapturing') : undefined"
-        @focus="capturingName = hotkey.name"
+        :status="captureError?.name === hotkey.name ? 'error' : undefined"
+        @focus="startCapture(hotkey.name)"
         @blur="handleBlur(hotkey.name)"
         @keydown="handleKeydown(hotkey.name, $event)"
       />
+      <span v-if="captureError?.name === hotkey.name" class="text-xs text-error">
+        {{ captureError.message }}
+      </span>
     </div>
   </div>
 </template>
@@ -20,7 +24,7 @@ import { ref } from "vue"
 import { useI18n } from "vue-i18n"
 import { useInterfaceStore } from "@/stores"
 import type { HotkeyOption } from "@/types/interfaceModel"
-import { buildHotkeyCombo } from "@/utils/hotkey"
+import { buildHotkeyCombo, getHotkeyCaptureIssue } from "@/utils/hotkey"
 import { resolveInterfaceText } from "@/utils/interface/content"
 
 const { option, value } = defineProps<{
@@ -35,6 +39,7 @@ const emit = defineEmits<{
 const { locale, t } = useI18n()
 const interfaceStore = useInterfaceStore()
 const capturingName = ref<string | null>(null)
+const captureError = ref<{ name: string; message: string } | null>(null)
 
 function resolveHotkeyLabel(label: string | undefined, fallback: string): string {
   return resolveInterfaceText(interfaceStore.interface, locale.value, label, fallback)
@@ -42,6 +47,11 @@ function resolveHotkeyLabel(label: string | undefined, fallback: string): string
 
 function getHotkeyValue(name: string): string {
   return value[name] ?? ""
+}
+
+function startCapture(name: string): void {
+  capturingName.value = name
+  captureError.value = null
 }
 
 function handleBlur(name: string): void {
@@ -52,8 +62,18 @@ function handleBlur(name: string): void {
 
 function handleKeydown(name: string, event: KeyboardEvent): void {
   event.preventDefault()
+  const issue = getHotkeyCaptureIssue(event)
+  if (issue) {
+    const messageKey =
+      issue === "meta_unsupported"
+        ? "option.hotkeyMetaUnsupported"
+        : "option.hotkeyTooManyModifiers"
+    captureError.value = { name, message: t(messageKey) }
+    return
+  }
   const combo = buildHotkeyCombo(event)
   if (!combo) return
+  captureError.value = null
   emit("update:value", { ...value, [name]: combo })
 }
 </script>

--- a/front/src/components/common/controls/OptionInputControl.vue
+++ b/front/src/components/common/controls/OptionInputControl.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="flex w-full max-w-sm flex-col gap-2">
+    <div v-for="input in option.inputs" :key="input.name" class="flex flex-col gap-1">
+      <span class="text-xs opacity-60">{{ resolveInputLabel(input.label, input.name) }}</span>
+      <NInputNumber
+        v-if="getInputControlType(input) === 'number'"
+        size="small"
+        :value="getInputNumberValue(input.name)"
+        :status="isInputError(input.name, input.verify) ? 'error' : undefined"
+        @update:value="handleInputNumberChange(input.name, $event, input)"
+      />
+      <NSwitch
+        v-else-if="getInputControlType(input) === 'bool'"
+        size="small"
+        :value="getBooleanInputValue(input.name)"
+        @update:value="handleBooleanInputChange(input.name, $event, input)"
+      />
+      <NInput
+        v-else-if="getInputControlType(input) === 'textarea'"
+        type="textarea"
+        size="small"
+        :value="getInputValue(input.name)"
+        :status="isInputError(input.name, input.verify) ? 'error' : undefined"
+        @update:value="handleInputChange(input.name, $event, input)"
+      />
+      <NInput
+        v-else
+        size="small"
+        :value="getInputValue(input.name)"
+        :status="isInputError(input.name, input.verify) ? 'error' : undefined"
+        @update:value="handleInputChange(input.name, $event, input)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue"
+import { useI18n } from "vue-i18n"
+import { showGlobalMessage } from "@/services/feedback/message"
+import { useInterfaceStore } from "@/stores"
+import type { InputCase, InputOption } from "@/types/interfaceModel"
+import { resolveInterfaceText } from "@/utils/interface/content"
+import { makeInterfaceInputSchema } from "@/validation/interfaceInput"
+
+const { option, value } = defineProps<{
+  option: InputOption
+  value: Record<string, string>
+}>()
+
+const emit = defineEmits<{
+  (event: "update:value", value: Record<string, string>): void
+}>()
+
+const { locale } = useI18n()
+const interfaceStore = useInterfaceStore()
+const inputInvalidState = ref<Record<string, boolean>>({})
+
+type InputControlType = "string" | "number" | "bool" | "textarea"
+
+function resolveInputLabel(label: string | undefined, fallback: string): string {
+  return resolveInterfaceText(interfaceStore.interface, locale.value, label, fallback)
+}
+
+function getInputValue(inputName: string): string {
+  return value[inputName] ?? ""
+}
+
+function setInputValue(inputName: string, nextValue: string): void {
+  emit("update:value", { ...value, [inputName]: nextValue })
+}
+
+function isInputAllowed(value: string, verify?: string): boolean {
+  if (!verify || value === "") return true
+  return makeInterfaceInputSchema(verify).safeParse(value).success
+}
+
+function isInputError(inputName: string, verify?: string): boolean {
+  return !isInputAllowed(getInputValue(inputName), verify)
+}
+
+function handleInputChange(inputName: string, value: string, input: InputCase): void {
+  const allowed = isInputAllowed(value, input.verify)
+  const wasInvalid = inputInvalidState.value[inputName] === true
+
+  if (allowed) {
+    setInputValue(inputName, value)
+    inputInvalidState.value = { ...inputInvalidState.value, [inputName]: false }
+    return
+  }
+
+  inputInvalidState.value = { ...inputInvalidState.value, [inputName]: true }
+  if (!wasInvalid && input.pattern_msg) {
+    const message = resolveInterfaceText(
+      interfaceStore.interface,
+      locale.value,
+      input.pattern_msg,
+      input.pattern_msg,
+    )
+    showGlobalMessage("error", message)
+  }
+}
+
+function getInputControlType(input: InputCase): InputControlType {
+  const pipelineType: string | undefined = input.pipeline_type
+  if (pipelineType === "int" || pipelineType === "number") return "number"
+  if (pipelineType === "bool") return "bool"
+  if (pipelineType === "textarea") return "textarea"
+  return "string"
+}
+
+function getInputNumberValue(inputName: string): number | null {
+  const value = getInputValue(inputName)
+  if (!value.trim()) return null
+  const numberValue = Number(value)
+  return Number.isFinite(numberValue) ? numberValue : null
+}
+
+function handleInputNumberChange(inputName: string, value: number | null, input: InputCase): void {
+  handleInputChange(inputName, value == null ? "" : String(value), input)
+}
+
+function getBooleanInputValue(inputName: string): boolean {
+  return ["true", "True", "TRUE", "yes", "Yes", "Y", "y", "1", "on", "On", "ON"].includes(
+    getInputValue(inputName),
+  )
+}
+
+function handleBooleanInputChange(
+  inputName: string,
+  value: string | number | boolean,
+  input: InputCase,
+): void {
+  const checked = value === true || value === 1 || value === "true" || value === "1"
+  handleInputChange(inputName, checked ? "true" : "false", input)
+}
+</script>

--- a/front/src/components/common/controls/OptionSelectControl.vue
+++ b/front/src/components/common/controls/OptionSelectControl.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="flex w-full max-w-xs items-center gap-2">
     <NSelect v-model:value="value" size="small" class="flex-1" :options="options" />
-    <NButton quaternary circle size="small" :disabled="refreshing" @click="emit('rescan')">
+    <NButton
+      v-if="showRescan"
+      quaternary
+      circle
+      size="small"
+      :disabled="refreshing"
+      @click="emit('rescan')"
+    >
       <template #icon>
         <NIcon size="16" :class="{ 'animate-spin': refreshing }">
           <RefreshOutline />
@@ -15,12 +22,17 @@
 import type { SelectOption } from "naive-ui"
 import { RefreshOutline } from "@vicons/ionicons5"
 
-defineProps<{
+const {
+  options,
+  refreshing = false,
+  showRescan = false,
+} = defineProps<{
   options: SelectOption[]
-  refreshing: boolean
+  refreshing?: boolean
+  showRescan?: boolean
 }>()
 
-const value = defineModel<string | null>("value")
+const value = defineModel<string | null>("value", { required: true })
 
 const emit = defineEmits<{
   (event: "rescan"): void

--- a/front/src/components/common/controls/OptionSwitchControl.vue
+++ b/front/src/components/common/controls/OptionSwitchControl.vue
@@ -1,0 +1,34 @@
+<template>
+  <NSwitch size="small" :value="value === checkedValue" @update:value="handleValueChange" />
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import type { SwitchOption } from "@/types/interfaceModel"
+
+const { option, value } = defineProps<{
+  option: SwitchOption
+  value: string
+}>()
+
+const emit = defineEmits<{
+  (event: "update:value", value: string): void
+}>()
+
+const checkedValue = computed(() =>
+  ["Yes", "yes", "Y", "y"].includes(option.cases[1].name)
+    ? option.cases[1].name
+    : option.cases[0].name,
+)
+
+const uncheckedValue = computed(() =>
+  ["Yes", "yes", "Y", "y"].includes(option.cases[1].name)
+    ? option.cases[0].name
+    : option.cases[1].name,
+)
+
+function handleValueChange(value: string | number | boolean): void {
+  const checked = value === true || value === 1 || value === "true" || value === "1"
+  emit("update:value", checked ? checkedValue.value : uncheckedValue.value)
+}
+</script>

--- a/front/src/components/routines/dialogs/composables/useTaskEnvironment.ts
+++ b/front/src/components/routines/dialogs/composables/useTaskEnvironment.ts
@@ -26,7 +26,13 @@ export interface TaskEnvironment {
 }
 
 function isDeviceControllerType(type: string): type is DeviceControllerType {
-  return type === "Adb" || type === "Win32" || type === "Gamepad" || type === "PlayCover"
+  return (
+    type === "Adb" ||
+    type === "Win32" ||
+    type === "Gamepad" ||
+    type === "PlayCover" ||
+    type === "WlRoots"
+  )
 }
 
 function getDeviceAddressValue(device: ConnectableDevice): string {

--- a/front/src/components/settings/sections/TaskSettingOptionRow.vue
+++ b/front/src/components/settings/sections/TaskSettingOptionRow.vue
@@ -46,12 +46,11 @@
     </div>
 
     <template v-if="nestedOptions.length > 0">
-      <OptionItem
+      <TaskSettingOptionRow
         v-for="childName in nestedOptions"
         :key="childName"
         :name="childName"
         :level="(level || 0) + 1"
-        :task-options="taskOptions"
       />
     </template>
   </template>
@@ -61,15 +60,16 @@
 import { computed, ref, watch } from "vue"
 import { useI18n } from "vue-i18n"
 import { showGlobalMessage } from "@/services/feedback/message"
-import { useInterfaceStore } from "@/stores"
+import { useInterfaceStore, useSettingsStore } from "@/stores"
 import type {
   CheckboxOption,
   ScanSelectOption,
   SelectOption,
   SwitchOption,
 } from "@/types/interfaceModel"
-import type { NullableTaskOptionValue } from "@/types/schedulerModel"
+import type { TaskOptionValue } from "@/types/schedulerModel"
 import { resolveInterfaceText } from "@/utils/interface/content"
+import { buildDefaultsFromOptionMap } from "@/utils/task-config/options"
 import { tryCatch } from "@/utils/tryCatch"
 import OptionCheckboxControl from "@/components/common/controls/OptionCheckboxControl.vue"
 import OptionHotkeyControl from "@/components/common/controls/OptionHotkeyControl.vue"
@@ -77,27 +77,38 @@ import OptionInputControl from "@/components/common/controls/OptionInputControl.
 import OptionSelectControl from "@/components/common/controls/OptionSelectControl.vue"
 import OptionSwitchControl from "@/components/common/controls/OptionSwitchControl.vue"
 
-const {
-  name,
-  level,
-  taskOptions: rawTaskOptions,
-} = defineProps<{
+const { name, level } = defineProps<{
   name: string
   level?: number
-  taskOptions: Record<string, NullableTaskOptionValue>
 }>()
 
 const { locale } = useI18n()
 const interfaceStore = useInterfaceStore()
-const taskOptions = computed(() => rawTaskOptions)
-const option = computed(() => interfaceStore.interface?.option?.[name])
+const settingsStore = useSettingsStore()
 const scanSelectRefreshing = ref(false)
+const option = computed(() => interfaceStore.interface?.option?.[name])
 
 const resolvedLabel = computed(() =>
   resolveInterfaceText(interfaceStore.interface, locale.value, option.value?.label, name),
 )
 
-function normalizeObjectValue(value: NullableTaskOptionValue | undefined): Record<string, string> {
+const defaultValue = computed<TaskOptionValue>(() => {
+  const currentOption = option.value
+  if (!currentOption) return ""
+  return buildDefaultsFromOptionMap({ [name]: currentOption })[name] ?? ""
+})
+
+const rawValue = computed<TaskOptionValue>(() =>
+  settingsStore.settings.globalOptionValues[name] === undefined
+    ? defaultValue.value
+    : settingsStore.settings.globalOptionValues[name],
+)
+
+function updateValue(value: TaskOptionValue): void {
+  void settingsStore.updateGlobalOptionValue(name, value)
+}
+
+function normalizeObjectValue(value: TaskOptionValue): Record<string, string> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {}
   return Object.fromEntries(
     Object.entries(value).filter(
@@ -107,53 +118,31 @@ function normalizeObjectValue(value: NullableTaskOptionValue | undefined): Recor
 }
 
 const switchValue = computed<string>({
-  get() {
-    const value = taskOptions.value[name]
-    return typeof value === "string" ? value : ""
-  },
-  set(value) {
-    taskOptions.value[name] = value
-  },
+  get: () => (typeof rawValue.value === "string" ? rawValue.value : ""),
+  set: updateValue,
 })
 
 const selectValue = computed<string | null>({
-  get() {
-    const value = taskOptions.value[name]
-    return typeof value === "string" ? value : null
-  },
-  set(value) {
-    taskOptions.value[name] = value
-  },
+  get: () => (typeof rawValue.value === "string" ? rawValue.value : null),
+  set: (value) => updateValue(value ?? ""),
 })
 
 const inputValue = computed<Record<string, string>>({
-  get() {
-    return normalizeObjectValue(taskOptions.value[name])
-  },
-  set(value) {
-    taskOptions.value[name] = value
-  },
+  get: () => normalizeObjectValue(rawValue.value),
+  set: updateValue,
 })
 
 const hotkeyValue = computed<Record<string, string>>({
-  get() {
-    return normalizeObjectValue(taskOptions.value[name])
-  },
-  set(value) {
-    taskOptions.value[name] = value
-  },
+  get: () => normalizeObjectValue(rawValue.value),
+  set: updateValue,
 })
 
 const checkboxValue = computed<string[]>({
-  get() {
-    const value = taskOptions.value[name]
-    return Array.isArray(value)
-      ? value.filter((item): item is string => typeof item === "string")
-      : []
-  },
-  set(value) {
-    taskOptions.value[name] = value
-  },
+  get: () =>
+    Array.isArray(rawValue.value)
+      ? rawValue.value.filter((item): item is string => typeof item === "string")
+      : [],
+  set: updateValue,
 })
 
 function resolveCaseLabel(label: string | undefined, fallback: string): string {
@@ -169,18 +158,24 @@ const selectOptions = computed(() => {
   }))
 })
 
+const fallbackSelectValue = computed(() => {
+  const currentOption = option.value
+  if (currentOption?.type !== "select" && currentOption?.type !== "scan_select") return ""
+  return currentOption.default_case ?? currentOption.cases[0]?.name ?? ""
+})
+
 const isSelectValueInvalid = computed(() => {
   const currentOption = option.value
   if (currentOption?.type !== "select" && currentOption?.type !== "scan_select") return false
-  const currentValue = taskOptions.value[name]
-  if (currentValue == null || typeof currentValue !== "string") return false
-  return !selectOptions.value.some((item) => item.value === currentValue)
+  return typeof rawValue.value === "string"
+    ? !selectOptions.value.some((item) => item.value === rawValue.value)
+    : true
 })
 
 watch(
   () => isSelectValueInvalid.value,
   (invalid) => {
-    if (invalid) taskOptions.value[name] = null
+    if (invalid) updateValue(fallbackSelectValue.value)
   },
   { immediate: true },
 )
@@ -189,28 +184,19 @@ async function handleRescanScanSelect(): Promise<void> {
   const currentOption = option.value
   if (!currentOption || currentOption.type !== "scan_select") return
 
-  const previousValue = taskOptions.value[name]
   scanSelectRefreshing.value = true
-  taskOptions.value[name] = null
   const [, err] = await tryCatch(() => interfaceStore.rescanScanSelectOption(name))
-  if (err) {
-    taskOptions.value[name] = previousValue
-    if (err.message) showGlobalMessage("error", err.message)
-  }
+  if (err?.message) showGlobalMessage("error", err.message)
   scanSelectRefreshing.value = false
 }
 
 function getSwitchNestedOptions(currentOption: SwitchOption): string[] {
-  const activeCase = currentOption.cases.find(
-    (caseItem) => caseItem.name === taskOptions.value[name],
-  )
+  const activeCase = currentOption.cases.find((caseItem) => caseItem.name === rawValue.value)
   return activeCase?.option || []
 }
 
 function getSelectNestedOptions(currentOption: SelectOption | ScanSelectOption): string[] {
-  const activeCase = currentOption.cases.find(
-    (caseItem) => caseItem.name === taskOptions.value[name],
-  )
+  const activeCase = currentOption.cases.find((caseItem) => caseItem.name === rawValue.value)
   return activeCase?.option || []
 }
 

--- a/front/src/components/settings/sections/TaskSettingsSection.vue
+++ b/front/src/components/settings/sections/TaskSettingsSection.vue
@@ -1,0 +1,74 @@
+<template>
+  <NCollapse :default-expanded-names="defaultExpandedNames" arrow-placement="right">
+    <NCollapseItem v-for="section in sections" :key="section.name" :name="section.name">
+      <template #header>
+        <div class="flex min-w-0 items-center gap-2">
+          <img
+            v-if="resolveSectionIcon(section.icon)"
+            :src="resolveSectionIcon(section.icon)"
+            alt=""
+            class="h-5 w-5 shrink-0 object-contain"
+          />
+          <div class="min-w-0">
+            <div class="font-medium">{{ resolveSectionLabel(section) }}</div>
+            <div v-if="section.description" class="text-xs opacity-60">
+              {{ resolveSectionDescription(section.description) }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <NEl
+        v-if="availableOptionNames(section).length > 0"
+        tag="div"
+        class="overflow-hidden rounded-lg border border-solid"
+        style="border-color: var(--divider-color)"
+      >
+        <TaskSettingOptionRow
+          v-for="optionName in availableOptionNames(section)"
+          :key="optionName"
+          :name="optionName"
+        />
+      </NEl>
+      <div v-else class="py-6 text-center text-sm opacity-50">
+        {{ t("settings.taskSettings.empty") }}
+      </div>
+    </NCollapseItem>
+  </NCollapse>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useI18n } from "vue-i18n"
+import { useInterfaceStore } from "@/stores"
+import type { SettingSection } from "@/types/interfaceModel"
+import { resolveInterfaceAssetUrl, resolveInterfaceText } from "@/utils/interface/content"
+import TaskSettingOptionRow from "@/components/settings/sections/TaskSettingOptionRow.vue"
+
+const { locale, t } = useI18n()
+const interfaceStore = useInterfaceStore()
+const sections = computed(() => interfaceStore.getSettingSections)
+const defaultExpandedNames = computed(() =>
+  sections.value
+    .filter((section) => section.default_expand !== false)
+    .map((section) => section.name),
+)
+
+function availableOptionNames(section: SettingSection): string[] {
+  return (section.option || []).filter(
+    (optionName) => interfaceStore.interface.option?.[optionName] !== undefined,
+  )
+}
+
+function resolveSectionLabel(section: SettingSection): string {
+  return resolveInterfaceText(interfaceStore.interface, locale.value, section.label, section.name)
+}
+
+function resolveSectionDescription(description: string): string {
+  return resolveInterfaceText(interfaceStore.interface, locale.value, description, description)
+}
+
+function resolveSectionIcon(icon: string | undefined): string | undefined {
+  return resolveInterfaceAssetUrl(interfaceStore.interface, locale.value, icon)
+}
+</script>

--- a/front/src/services/api/modules/device.ts
+++ b/front/src/services/api/modules/device.ts
@@ -5,7 +5,7 @@ export interface PostDeviceResult {
   message: string
 }
 
-export type DeviceControllerType = "Adb" | "Win32" | "Gamepad" | "PlayCover"
+export type DeviceControllerType = "Adb" | "Win32" | "Gamepad" | "PlayCover" | "WlRoots"
 
 export interface AdbDevice {
   type: "Adb"
@@ -42,7 +42,18 @@ export interface PlayCoverDevice {
   uuid?: string
 }
 
-export type ConnectableDevice = AdbDevice | Win32Device | GamepadDevice | PlayCoverDevice
+export interface WlRootsDevice {
+  type: "WlRoots"
+  name?: string
+  address: string
+}
+
+export type ConnectableDevice =
+  | AdbDevice
+  | Win32Device
+  | GamepadDevice
+  | PlayCoverDevice
+  | WlRootsDevice
 
 export interface ConnectDevicePayload {
   controller_name: string

--- a/front/src/stores/device/deviceConnection.ts
+++ b/front/src/stores/device/deviceConnection.ts
@@ -997,6 +997,20 @@ function buildStoredLastConnectedDevice(
       uuid: "",
     }
   }
+  if (deviceInfo.type === "WlRoots") {
+    return {
+      type: "WlRoots",
+      controller_name: controllerName,
+      fingerprint: buildDeviceFingerprint(deviceInfo),
+      adb_path: "",
+      address: deviceInfo.address,
+      class_name: "",
+      window_name: deviceInfo.name || "",
+      hWnd: 0,
+      gamepad_type: 0,
+      uuid: "",
+    }
+  }
   return {
     type: "PlayCover",
     controller_name: controllerName,

--- a/front/src/stores/interface/interface.ts
+++ b/front/src/stores/interface/interface.ts
@@ -3,7 +3,14 @@ import {
   getInterface,
   rescanScanSelectOption as requestRescanScanSelectOption,
 } from "@/services/api"
-import type { InterfaceModel, Option, Preset, Pretask, Task } from "@/types/interfaceModel"
+import type {
+  InterfaceModel,
+  Option,
+  Preset,
+  Pretask,
+  SettingSection,
+  Task,
+} from "@/types/interfaceModel"
 import type { TaskListItem } from "@/types/taskConfigModel"
 
 export const useInterfaceStore = defineStore("interface", {
@@ -21,6 +28,7 @@ export const useInterfaceStore = defineStore("interface", {
     },
     getPresetList: (state): Preset[] => state.interface?.preset || [],
     getPretasks: (state): Pretask[] => state.interface?.pretask || [],
+    getSettingSections: (state): SettingSection[] => state.interface?.setting || [],
   },
   actions: {
     async setInterface() {

--- a/front/src/stores/settings/settings.test.ts
+++ b/front/src/stores/settings/settings.test.ts
@@ -1,0 +1,73 @@
+import { createPinia, setActivePinia } from "pinia"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/services/api", () => ({
+  getSettings: vi.fn<() => void>(),
+  updateSettings: vi.fn<() => void>(),
+}))
+
+import * as api from "@/services/api"
+import { useSettingsStore } from "@/stores/settings/settings"
+
+function deferred<T>() {
+  let resolvePromise: (value: T) => void = () => undefined
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve
+  })
+  return { promise, resolve: resolvePromise }
+}
+
+describe("settings persistence", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it("serializes rapid whole-document writes without losing either field", async () => {
+    const first = deferred<boolean>()
+    const second = deferred<boolean>()
+    vi.mocked(api.updateSettings)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const store = useSettingsStore()
+    const firstUpdate = store.updateSetting("runtime", "timeout", 120)
+    const secondUpdate = store.updateSetting("runtime", "retryInterval", 10)
+
+    await vi.waitFor(() => expect(api.updateSettings).toHaveBeenCalledTimes(1))
+    first.resolve(true)
+    await vi.waitFor(() => expect(api.updateSettings).toHaveBeenCalledTimes(2))
+
+    expect(vi.mocked(api.updateSettings).mock.calls[1][0].runtime).toMatchObject({
+      timeout: 120,
+      retryInterval: 10,
+    })
+
+    second.resolve(true)
+    await expect(Promise.all([firstUpdate, secondUpdate])).resolves.toEqual([true, true])
+    expect(store.settings.runtime).toMatchObject({ timeout: 120, retryInterval: 10 })
+  })
+
+  it("does not let an older failed write roll back a newer value", async () => {
+    const first = deferred<boolean>()
+    const second = deferred<boolean>()
+    vi.mocked(api.updateSettings)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const store = useSettingsStore()
+    const firstUpdate = store.updateSetting("runtime", "timeout", 120)
+    const secondUpdate = store.updateSetting("runtime", "timeout", 180)
+
+    await vi.waitFor(() => expect(api.updateSettings).toHaveBeenCalledTimes(1))
+    first.resolve(false)
+    await vi.waitFor(() => expect(api.updateSettings).toHaveBeenCalledTimes(2))
+
+    expect(store.settings.runtime.timeout).toBe(180)
+    expect(vi.mocked(api.updateSettings).mock.calls[1][0].runtime.timeout).toBe(180)
+
+    second.resolve(true)
+    await expect(Promise.all([firstUpdate, secondUpdate])).resolves.toEqual([false, true])
+    expect(store.settings.runtime.timeout).toBe(180)
+  })
+})

--- a/front/src/stores/settings/settings.ts
+++ b/front/src/stores/settings/settings.ts
@@ -55,6 +55,26 @@ const defaultSettings: SettingsModel = {
 
 const DARK_MODE_KEY = "darkMode"
 
+let saveQueue: Promise<void> = Promise.resolve()
+
+function enqueueSettingsSave(save: () => Promise<boolean>): Promise<boolean> {
+  const result = saveQueue.then(save)
+  saveQueue = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return result
+}
+
+function applySettingsPatch<K extends keyof SettingsModel, P extends keyof SettingsModel[K]>(
+  settings: SettingsModel,
+  category: K,
+  key: P,
+  value: SettingsModel[K][P],
+) {
+  settings[category][key] = value
+}
+
 function getCachedDarkMode(): "auto" | boolean {
   if (typeof window === "undefined" || typeof localStorage === "undefined") return "auto"
   const cached = localStorage.getItem(DARK_MODE_KEY)
@@ -76,7 +96,9 @@ export const useSettingsStore = defineStore("settings", {
     }
     return {
       settings,
+      persistedSettings: deepClone(settings),
       loading: false,
+      pendingSaveCount: 0,
       initialized: false,
       systemPrefersDark:
         typeof window !== "undefined" && window.matchMedia
@@ -131,6 +153,7 @@ export const useSettingsStore = defineStore("settings", {
           },
           globalOptionValues: { ...data.globalOptionValues },
         }
+        this.persistedSettings = deepClone(this.settings)
         // 确保本地缓存与服务器设置同步
         localStorage.setItem(DARK_MODE_KEY, String(this.settings.ui.darkMode))
       }
@@ -139,20 +162,55 @@ export const useSettingsStore = defineStore("settings", {
     },
 
     async saveSettings(newSettings?: SettingsModel) {
+      const payload = deepClone(newSettings || this.settings)
+      this.pendingSaveCount += 1
       this.loading = true
-      const payload = newSettings || this.settings
-      const [success, err] = await tryCatch(() => updateSettings(payload))
+      const [success, err] = await tryCatch(() =>
+        enqueueSettingsSave(async () => {
+          const saved = await updateSettings(payload)
+          if (saved) {
+            this.persistedSettings = deepClone(payload)
+          }
+          return saved
+        }),
+      )
+      this.pendingSaveCount -= 1
+      this.loading = this.pendingSaveCount > 0
       if (err) {
         console.error("Failed to save settings:", err)
-        this.loading = false
         return false
       }
       if (success) {
-        this.settings = deepClone(payload)
         // 保存成功后更新本地缓存
         localStorage.setItem(DARK_MODE_KEY, String(this.settings.ui.darkMode))
       }
-      this.loading = false
+      return success
+    },
+
+    async saveSettingPatch<K extends keyof SettingsModel, P extends keyof SettingsModel[K]>(
+      category: K,
+      key: P,
+      value: SettingsModel[K][P],
+    ) {
+      this.pendingSaveCount += 1
+      this.loading = true
+      const [success, err] = await tryCatch(() =>
+        enqueueSettingsSave(async () => {
+          const payload = deepClone(this.persistedSettings)
+          applySettingsPatch(payload, category, key, deepClone(value))
+          const saved = await updateSettings(payload)
+          if (saved) {
+            this.persistedSettings = payload
+          }
+          return saved
+        }),
+      )
+      this.pendingSaveCount -= 1
+      this.loading = this.pendingSaveCount > 0
+      if (err) {
+        console.error("Failed to save settings:", err)
+        return false
+      }
       return success
     },
 
@@ -161,8 +219,6 @@ export const useSettingsStore = defineStore("settings", {
       key: P,
       value: SettingsModel[K][P],
     ) {
-      const previousSettings = deepClone(this.settings)
-
       const updatedSettings = {
         ...this.settings,
         [category]: {
@@ -178,19 +234,24 @@ export const useSettingsStore = defineStore("settings", {
       }
 
       // 后台保存
-      const success = await this.saveSettings(updatedSettings)
+      const success = await this.saveSettingPatch(category, key, value)
       if (!success) {
-        // 保存失败时回滚到之前的状态
-        this.settings = previousSettings
-        if (category === "ui" && key === "darkMode") {
-          localStorage.setItem(DARK_MODE_KEY, String(previousSettings.ui.darkMode))
+        if (Object.is(this.settings[category][key], value)) {
+          applySettingsPatch(
+            this.settings,
+            category,
+            key,
+            deepClone(this.persistedSettings[category][key]),
+          )
+          if (category === "ui" && key === "darkMode") {
+            localStorage.setItem(DARK_MODE_KEY, String(this.settings.ui.darkMode))
+          }
         }
       }
       return success
     },
 
     async updateGlobalOptionValue(optionKey: string, value: TaskOptionValue) {
-      const previousSettings = deepClone(this.settings)
       this.settings = {
         ...this.settings,
         globalOptionValues: {
@@ -199,11 +260,17 @@ export const useSettingsStore = defineStore("settings", {
         },
       }
 
-      const success = await this.saveSettings()
-      if (!success) {
-        this.settings = previousSettings
+      const success = await this.saveSettingPatch("globalOptionValues", optionKey, value)
+      if (success || !Object.is(this.settings.globalOptionValues[optionKey], value)) {
+        return success
       }
-      return success
+      const persistedValue = this.persistedSettings.globalOptionValues[optionKey]
+      if (persistedValue === undefined) {
+        delete this.settings.globalOptionValues[optionKey]
+        return false
+      }
+      this.settings.globalOptionValues[optionKey] = deepClone(persistedValue)
+      return false
     },
 
     addRecentDevice(deviceConfig: PanelLastConnectedDevice) {

--- a/front/src/stores/settings/settings.ts
+++ b/front/src/stores/settings/settings.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia"
 import { tryCatch } from "@/utils/tryCatch"
 import { getSettings, updateSettings } from "@/services/api"
+import type { TaskOptionValue } from "@/types/schedulerModel"
 import type { PanelLastConnectedDevice, SettingsModel } from "@/types/settingsModel"
 
 const defaultSettings: SettingsModel = {
@@ -49,6 +50,7 @@ const defaultSettings: SettingsModel = {
     recentDevices: [],
     customDevices: [],
   },
+  globalOptionValues: {},
 }
 
 const DARK_MODE_KEY = "darkMode"
@@ -127,6 +129,7 @@ export const useSettingsStore = defineStore("settings", {
             recentDevices: data.panel?.recentDevices ?? [],
             customDevices: data.panel?.customDevices ?? this.settings.panel.customDevices ?? [],
           },
+          globalOptionValues: { ...data.globalOptionValues },
         }
         // 确保本地缓存与服务器设置同步
         localStorage.setItem(DARK_MODE_KEY, String(this.settings.ui.darkMode))
@@ -182,6 +185,23 @@ export const useSettingsStore = defineStore("settings", {
         if (category === "ui" && key === "darkMode") {
           localStorage.setItem(DARK_MODE_KEY, String(previousSettings.ui.darkMode))
         }
+      }
+      return success
+    },
+
+    async updateGlobalOptionValue(optionKey: string, value: TaskOptionValue) {
+      const previousSettings = deepClone(this.settings)
+      this.settings = {
+        ...this.settings,
+        globalOptionValues: {
+          ...this.settings.globalOptionValues,
+          [optionKey]: value,
+        },
+      }
+
+      const success = await this.saveSettings()
+      if (!success) {
+        this.settings = previousSettings
       }
       return success
     },

--- a/front/src/types/interfaceModel.ts
+++ b/front/src/types/interfaceModel.ts
@@ -135,6 +135,15 @@ export interface Group {
   default_expand?: boolean
 }
 
+export interface SettingSection {
+  name: string
+  label?: string
+  description?: string
+  icon?: string
+  option?: string[]
+  default_expand?: boolean
+}
+
 export interface OptionCase {
   name: string
   label?: string
@@ -154,6 +163,13 @@ export interface InputCase {
   pipeline_type?: InputPipelineType
   verify?: string
   pattern_msg?: string
+}
+
+export interface HotkeyCase {
+  name: string
+  label?: string
+  description?: string
+  default?: string
 }
 
 interface OptionBase {
@@ -176,6 +192,11 @@ export interface InputOption extends OptionBase {
   inputs: InputCase[]
 }
 
+export interface HotkeyOption extends OptionBase {
+  type: "hotkey"
+  hotkeys: HotkeyCase[]
+}
+
 export interface CheckboxOption extends OptionBase {
   type: "checkbox"
   cases: OptionCase[]
@@ -196,7 +217,13 @@ export interface ScanSelectOption extends OptionBase {
   default_case?: string
 }
 
-export type Option = SelectOption | InputOption | CheckboxOption | SwitchOption | ScanSelectOption
+export type Option =
+  | SelectOption
+  | InputOption
+  | HotkeyOption
+  | CheckboxOption
+  | SwitchOption
+  | ScanSelectOption
 
 export type PresetTaskOptionValue = string | string[] | Record<string, string>
 
@@ -238,6 +265,7 @@ export interface InterfaceModel {
   pretask?: Pretask[]
   option?: Record<string, Option>
   global_option?: string[]
+  setting?: SettingSection[]
   import?: string[]
   preset?: Preset[]
 }

--- a/front/src/types/interfaceModel.ts
+++ b/front/src/types/interfaceModel.ts
@@ -52,6 +52,10 @@ export interface PlayCoverController {
   uuid?: string
 }
 
+export interface WlRootsController {
+  use_win32_vk_code?: boolean
+}
+
 export type GamepadType = "Xbox360" | "DualShock4" | "DS4"
 
 export interface GamepadController {
@@ -61,7 +65,7 @@ export interface GamepadController {
   screencap?: GamepadScreencap
 }
 
-export type ControllerType = "Adb" | "Win32" | "MacOS" | "PlayCover" | "Gamepad"
+export type ControllerType = "Adb" | "Win32" | "MacOS" | "PlayCover" | "WlRoots" | "Gamepad"
 
 export interface Controller {
   name: string
@@ -73,6 +77,7 @@ export interface Controller {
   win32?: Win32Controller
   macos?: MacOSController
   playcover?: PlayCoverController
+  wlroots?: WlRootsController
   gamepad?: GamepadController
   display_short_side?: number
   display_long_side?: number

--- a/front/src/types/schedulerModel.ts
+++ b/front/src/types/schedulerModel.ts
@@ -48,7 +48,7 @@ export interface TaskExecutionPayload {
 
 export interface ScheduledTaskDeviceConfig {
   controller_name: string
-  device_type: "Adb" | "Win32" | "Gamepad" | "PlayCover"
+  device_type: "Adb" | "Win32" | "Gamepad" | "PlayCover" | "WlRoots"
   device_address: string
 }
 

--- a/front/src/types/settingsModel.ts
+++ b/front/src/types/settingsModel.ts
@@ -51,7 +51,7 @@ export interface AboutInfo {
 
 // 面板持久化设备信息
 export interface PanelLastConnectedDevice {
-  type: "Adb" | "Win32" | "Gamepad" | "PlayCover"
+  type: "Adb" | "Win32" | "Gamepad" | "PlayCover" | "WlRoots"
   controller_name: string
   fingerprint: string
   adb_path: string

--- a/front/src/types/settingsModel.ts
+++ b/front/src/types/settingsModel.ts
@@ -1,3 +1,5 @@
+import type { TaskOptionValue } from "@/types/schedulerModel"
+
 // 更新设置
 export interface UpdateSettings {
   autoUpdate: boolean
@@ -84,4 +86,5 @@ export interface SettingsModel {
   runtime: RuntimeSettings
   about: AboutInfo
   panel: PanelSettings
+  globalOptionValues: Record<string, TaskOptionValue>
 }

--- a/front/src/utils/hotkey.test.ts
+++ b/front/src/utils/hotkey.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { buildHotkeyCombo } from "@/utils/hotkey"
+import { buildHotkeyCombo, getHotkeyCaptureIssue } from "@/utils/hotkey"
 
 describe("buildHotkeyCombo", () => {
-  it("orders Ctrl, Alt, and Shift modifiers consistently", () => {
+  it("rejects shortcuts with more than two modifiers", () => {
     const event = new KeyboardEvent("keydown", {
       key: "a",
       ctrlKey: true,
@@ -11,7 +11,38 @@ describe("buildHotkeyCombo", () => {
       shiftKey: true,
     })
 
-    expect(buildHotkeyCombo(event)).toBe("Ctrl+Alt+Shift+A")
+    expect(buildHotkeyCombo(event)).toBeNull()
+  })
+
+  it("orders two modifiers consistently", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      altKey: true,
+    })
+
+    expect(buildHotkeyCombo(event)).toBe("Ctrl+Alt+A")
+  })
+
+  it("rejects Meta combinations", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      metaKey: true,
+    })
+
+    expect(buildHotkeyCombo(event)).toBeNull()
+    expect(getHotkeyCaptureIssue(event)).toBe("meta_unsupported")
+  })
+
+  it("reports shortcuts with too many modifiers", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      altKey: true,
+      shiftKey: true,
+    })
+
+    expect(getHotkeyCaptureIssue(event)).toBe("too_many_modifiers")
   })
 
   it.each(["Control", "Alt", "Shift", "Meta"])("returns null for a pure %s modifier", (key) => {

--- a/front/src/utils/hotkey.test.ts
+++ b/front/src/utils/hotkey.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { buildHotkeyCombo } from "@/utils/hotkey"
+
+describe("buildHotkeyCombo", () => {
+  it("orders Ctrl, Alt, and Shift modifiers consistently", () => {
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      ctrlKey: true,
+      altKey: true,
+      shiftKey: true,
+    })
+
+    expect(buildHotkeyCombo(event)).toBe("Ctrl+Alt+Shift+A")
+  })
+
+  it.each(["Control", "Alt", "Shift", "Meta"])("returns null for a pure %s modifier", (key) => {
+    const event = new KeyboardEvent("keydown", { key })
+
+    expect(buildHotkeyCombo(event)).toBeNull()
+  })
+
+  it.each([
+    ["a", "A"],
+    ["z", "Z"],
+  ])("uppercases single-character key %s", (key, expected) => {
+    const event = new KeyboardEvent("keydown", { key })
+
+    expect(buildHotkeyCombo(event)).toBe(expected)
+  })
+
+  it.each([
+    ["f1", "F1"],
+    ["F12", "F12"],
+  ])("normalizes function key %s to %s", (key, expected) => {
+    const event = new KeyboardEvent("keydown", { key })
+
+    expect(buildHotkeyCombo(event)).toBe(expected)
+  })
+
+  it.each([
+    ["ArrowLeft", "Left"],
+    ["ArrowRight", "Right"],
+    ["ArrowUp", "Up"],
+    ["ArrowDown", "Down"],
+    ["Escape", "Esc"],
+    [" ", "Space"],
+    ["Spacebar", "Space"],
+  ])("normalizes %s to %s", (key, expected) => {
+    const event = new KeyboardEvent("keydown", { key })
+
+    expect(buildHotkeyCombo(event)).toBe(expected)
+  })
+})

--- a/front/src/utils/hotkey.ts
+++ b/front/src/utils/hotkey.ts
@@ -1,0 +1,33 @@
+const modifierKeys: Record<string, true> = {
+  Control: true,
+  Shift: true,
+  Alt: true,
+  Meta: true,
+}
+
+function normalizePrimaryKey(key: string): string {
+  const aliases: Record<string, string> = {
+    ArrowLeft: "Left",
+    ArrowRight: "Right",
+    ArrowUp: "Up",
+    ArrowDown: "Down",
+    Escape: "Esc",
+    " ": "Space",
+    Spacebar: "Space",
+  }
+  if (aliases[key]) return aliases[key]
+  if (key.length === 1) return key.toUpperCase()
+  if (/^F\d{1,2}$/i.test(key)) return key.toUpperCase()
+  return key
+}
+
+export function buildHotkeyCombo(event: KeyboardEvent): string | null {
+  if (modifierKeys[event.key]) return null
+
+  const parts: string[] = []
+  if (event.ctrlKey) parts.push("Ctrl")
+  if (event.altKey) parts.push("Alt")
+  if (event.shiftKey) parts.push("Shift")
+  parts.push(normalizePrimaryKey(event.key))
+  return parts.join("+")
+}

--- a/front/src/utils/hotkey.ts
+++ b/front/src/utils/hotkey.ts
@@ -5,6 +5,14 @@ const modifierKeys: Record<string, true> = {
   Meta: true,
 }
 
+export type HotkeyCaptureIssue = "meta_unsupported" | "too_many_modifiers"
+
+export function getHotkeyCaptureIssue(event: KeyboardEvent): HotkeyCaptureIssue | null {
+  if (event.metaKey) return "meta_unsupported"
+  const modifierCount = Number(event.ctrlKey) + Number(event.altKey) + Number(event.shiftKey)
+  return modifierCount > 2 ? "too_many_modifiers" : null
+}
+
 function normalizePrimaryKey(key: string): string {
   const aliases: Record<string, string> = {
     ArrowLeft: "Left",
@@ -22,12 +30,14 @@ function normalizePrimaryKey(key: string): string {
 }
 
 export function buildHotkeyCombo(event: KeyboardEvent): string | null {
+  if (getHotkeyCaptureIssue(event)) return null
   if (modifierKeys[event.key]) return null
 
   const parts: string[] = []
   if (event.ctrlKey) parts.push("Ctrl")
   if (event.altKey) parts.push("Alt")
   if (event.shiftKey) parts.push("Shift")
+  if (parts.length > 2) return null
   parts.push(normalizePrimaryKey(event.key))
   return parts.join("+")
 }

--- a/front/src/utils/panel/device.test.ts
+++ b/front/src/utils/panel/device.test.ts
@@ -12,7 +12,13 @@ import {
   getStoredDeviceIdentity,
   storedDeviceMatchesController,
 } from "@/utils/panel/device"
-import type { AdbDevice, GamepadDevice, PlayCoverDevice, Win32Device } from "@/services/api"
+import type {
+  AdbDevice,
+  GamepadDevice,
+  PlayCoverDevice,
+  Win32Device,
+  WlRootsDevice,
+} from "@/services/api"
 import type { PanelLastConnectedDevice } from "@/types/settingsModel"
 
 const adbDevice: AdbDevice = {
@@ -48,6 +54,12 @@ const playCoverDevice: PlayCoverDevice = {
   name: "playcover-device",
   address: "127.0.0.1:1717",
   uuid: "uuid-001",
+}
+
+const wlRootsDevice: WlRootsDevice = {
+  type: "WlRoots",
+  name: "Wayland compositor",
+  address: "/run/user/1000/wayland-1",
 }
 
 describe("isAdbDevice", () => {
@@ -119,6 +131,10 @@ describe("getDeviceIdentity", () => {
 
   it("returns address for PlayCover device", () => {
     expect(getDeviceIdentity(playCoverDevice)).toBe("127.0.0.1:1717")
+  })
+
+  it("returns socket path for WlRoots device", () => {
+    expect(getDeviceIdentity(wlRootsDevice)).toBe("/run/user/1000/wayland-1")
   })
 })
 
@@ -260,6 +276,10 @@ describe("buildDeviceFingerprint", () => {
   it("handles PlayCover device without uuid", () => {
     const device: PlayCoverDevice = { type: "PlayCover", address: "127.0.0.1:1717" }
     expect(buildDeviceFingerprint(device)).toBe("playcover|127.0.0.1:1717|")
+  })
+
+  it("builds wlroots|socket-path for WlRoots device", () => {
+    expect(buildDeviceFingerprint(wlRootsDevice)).toBe("wlroots|/run/user/1000/wayland-1")
   })
 })
 

--- a/front/src/utils/panel/device.ts
+++ b/front/src/utils/panel/device.ts
@@ -35,7 +35,7 @@ export function getDeviceIdentity(deviceInfo: ConnectableDevice): string {
 
 /** Stable identity for a persisted last-connected snapshot (same semantics as getDeviceIdentity). */
 export function getStoredDeviceIdentity(stored: PanelLastConnectedDevice): string {
-  if (stored.type === "Adb" || stored.type === "PlayCover") {
+  if (stored.type === "Adb" || stored.type === "PlayCover" || stored.type === "WlRoots") {
     return stored.address
   }
   if (stored.type === "Win32") {
@@ -95,6 +95,9 @@ export function buildDeviceFingerprint(deviceInfo: ConnectableDevice): string {
   if (isGamepadDevice(deviceInfo)) {
     return `gamepad|${deviceInfo.hWnd}|${deviceInfo.gamepad_type}`
   }
+  if (deviceInfo.type === "WlRoots") {
+    return `wlroots|${deviceInfo.address}`
+  }
   return `playcover|${deviceInfo.address}|${deviceInfo.uuid || ""}`
 }
 
@@ -116,6 +119,9 @@ export function getStoredDeviceFingerprint(stored: PanelLastConnectedDevice): st
   }
   if (normalizedType === "gamepad") {
     return `gamepad|${stored.hWnd}|${stored.gamepad_type}`
+  }
+  if (normalizedType === "wlroots") {
+    return `wlroots|${stored.address}`
   }
   return `playcover|${stored.address}|${stored.uuid}`
 }

--- a/front/src/utils/task-config/options.test.ts
+++ b/front/src/utils/task-config/options.test.ts
@@ -111,6 +111,20 @@ describe("buildDefaultsFromOptionMap", () => {
     })
   })
 
+  it("builds object defaults for hotkey types", () => {
+    const optionMap: Record<string, Option> = {
+      shortcuts: {
+        type: "hotkey",
+        hotkeys: [{ name: "start", default: "Ctrl+S" }, { name: "stop" }],
+      },
+    }
+
+    const result = buildDefaultsFromOptionMap(optionMap)
+    expect(result).toEqual({
+      shortcuts: { start: "Ctrl+S", stop: "" },
+    })
+  })
+
   it("builds defaults for switch types", () => {
     const optionMap: Record<string, Option> = {
       toggle: {

--- a/front/src/utils/task-config/options.ts
+++ b/front/src/utils/task-config/options.ts
@@ -1,4 +1,5 @@
 import type {
+  HotkeyOption,
   InputOption,
   Option,
   ScanSelectOption,
@@ -39,6 +40,14 @@ function buildInputDefault(option: InputOption): Record<string, string> {
   return inputDefaults
 }
 
+function buildHotkeyDefault(option: HotkeyOption): Record<string, string> {
+  const hotkeyDefaults: Record<string, string> = {}
+  for (const hotkey of option.hotkeys) {
+    hotkeyDefaults[hotkey.name] = hotkey.default ?? ""
+  }
+  return hotkeyDefaults
+}
+
 function buildSwitchDefault(option: SwitchOption): string {
   const defaultValue = option.default_case ?? option.cases[0]?.name ?? ""
   return typeof defaultValue === "string" ? defaultValue : ""
@@ -59,6 +68,11 @@ export function buildDefaultsFromOptionMap(
 
     if (option.type === "input") {
       options[key] = buildInputDefault(option)
+      continue
+    }
+
+    if (option.type === "hotkey") {
+      options[key] = buildHotkeyDefault(option)
       continue
     }
 

--- a/front/src/validation/device.test.ts
+++ b/front/src/validation/device.test.ts
@@ -111,6 +111,21 @@ describe("customDeviceAddressSchema", () => {
       customDeviceAddressSchema.safeParse({ type: "Gamepad", address: "12345|2" }).success,
     ).toBe(false)
   })
+
+  it("accepts and trims a WlRoots socket path", () => {
+    expect(
+      customDeviceAddressSchema.parse({
+        type: "WlRoots",
+        address: " /run/user/1000/wayland-1 ",
+      }),
+    ).toEqual({ type: "WlRoots", address: "/run/user/1000/wayland-1" })
+  })
+
+  it("rejects an empty WlRoots socket path", () => {
+    expect(customDeviceAddressSchema.safeParse({ type: "WlRoots", address: "   " }).success).toBe(
+      false,
+    )
+  })
 })
 
 describe("runtimeDeviceAddressSchema", () => {
@@ -134,6 +149,13 @@ describe("runtimeDeviceAddressSchema", () => {
     expect(
       runtimeDeviceAddressSchema.safeParse({ type: "PlayCover", address: "emulator-5554" }).success,
     ).toBe(false)
+  })
+
+  it("accepts a scanned WlRoots socket path", () => {
+    expect(runtimeDeviceAddressSchema.parse({ type: "WlRoots", address: " wayland-1 " })).toEqual({
+      type: "WlRoots",
+      address: "wayland-1",
+    })
   })
 })
 

--- a/front/src/validation/device.ts
+++ b/front/src/validation/device.ts
@@ -79,6 +79,10 @@ export const customDeviceAddressSchema = z.discriminatedUnion("type", [
     type: z.literal("Gamepad"),
     address: gamepadAddressSchema,
   }),
+  z.object({
+    type: z.literal("WlRoots"),
+    address: z.string().trim().min(1, "WlRoots socket path must not be empty"),
+  }),
 ])
 
 export type CustomDeviceAddress = z.output<typeof customDeviceAddressSchema>
@@ -100,6 +104,10 @@ export const runtimeDeviceAddressSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("Gamepad"),
     address: gamepadAddressSchema,
+  }),
+  z.object({
+    type: z.literal("WlRoots"),
+    address: z.string().trim().min(1, "WlRoots socket path must not be empty"),
   }),
 ])
 

--- a/front/src/views/SettingsView.vue
+++ b/front/src/views/SettingsView.vue
@@ -32,6 +32,19 @@
         <UpdateSettingsSection @show-update="handleShowUpdate" />
       </NCard>
 
+      <!-- PI task settings -->
+      <NCard v-if="activeSection === 'taskSettings'">
+        <template #header>
+          <h2 class="flex items-center gap-2 text-lg font-semibold">
+            <NIcon size="20" style="color: var(--primary-color)">
+              <ConstructOutline />
+            </NIcon>
+            {{ t("settings.anchor.taskSettings") }}
+          </h2>
+        </template>
+        <TaskSettingsSection />
+      </NCard>
+
       <!-- Runtime -->
       <NCard v-if="activeSection === 'runtime'">
         <template #header>
@@ -97,6 +110,7 @@ import type { MenuOption } from "naive-ui"
 import {
   ArrowUpCircleOutline,
   ColorPaletteOutline,
+  ConstructOutline,
   InformationCircleOutline,
   NotificationsOutline,
   SettingsOutline,
@@ -105,11 +119,13 @@ import UpdateDialog from "@/components/settings/dialogs/UpdateDialog.vue"
 import AboutSettingsSection from "@/components/settings/sections/AboutSettingsSection.vue"
 import NotificationSettingsSection from "@/components/settings/sections/NotificationSettingsSection.vue"
 import RuntimeSettingsSection from "@/components/settings/sections/RuntimeSettingsSection.vue"
+import TaskSettingsSection from "@/components/settings/sections/TaskSettingsSection.vue"
 import UISettingsSection from "@/components/settings/sections/UISettingsSection.vue"
 import UpdateSettingsSection from "@/components/settings/sections/UpdateSettingsSection.vue"
 import type { UpdateInfo } from "@/services/api"
+import { useInterfaceStore } from "@/stores"
 
-type SettingsSectionKey = "update" | "runtime" | "ui" | "notification" | "about"
+type SettingsSectionKey = "update" | "taskSettings" | "runtime" | "ui" | "notification" | "about"
 
 interface SettingsSection {
   id: SettingsSectionKey
@@ -118,17 +134,34 @@ interface SettingsSection {
 }
 
 const { t } = useI18n()
+const interfaceStore = useInterfaceStore()
 const activeSection = ref<SettingsSectionKey>("update")
 const showUpdateDialog = ref(false)
 const updateInfo = ref<UpdateInfo | null>(null)
 
-const sections = computed<SettingsSection[]>(() => [
-  { id: "update", label: t("settings.anchor.update"), icon: ArrowUpCircleOutline },
-  { id: "runtime", label: t("settings.anchor.runtime"), icon: SettingsOutline },
-  { id: "ui", label: t("settings.anchor.ui"), icon: ColorPaletteOutline },
-  { id: "notification", label: t("settings.anchor.notification"), icon: NotificationsOutline },
-  { id: "about", label: t("settings.anchor.about"), icon: InformationCircleOutline },
-])
+const sections = computed<SettingsSection[]>(() => {
+  const values: SettingsSection[] = [
+    { id: "update", label: t("settings.anchor.update"), icon: ArrowUpCircleOutline },
+  ]
+  if (interfaceStore.getSettingSections.length > 0) {
+    values.push({
+      id: "taskSettings",
+      label: t("settings.anchor.taskSettings"),
+      icon: ConstructOutline,
+    })
+  }
+  values.push(
+    { id: "runtime", label: t("settings.anchor.runtime"), icon: SettingsOutline },
+    { id: "ui", label: t("settings.anchor.ui"), icon: ColorPaletteOutline },
+    {
+      id: "notification",
+      label: t("settings.anchor.notification"),
+      icon: NotificationsOutline,
+    },
+    { id: "about", label: t("settings.anchor.about"), icon: InformationCircleOutline },
+  )
+  return values
+})
 
 const menuOptions = computed<MenuOption[]>(() =>
   sections.value.map((section) => ({

--- a/maa_worker/device_service.py
+++ b/maa_worker/device_service.py
@@ -10,6 +10,7 @@ from maa.controller import (
     GamepadController,
     PlayCoverController,
     Win32Controller,
+    WlRootsController,
 )
 from maa.toolkit import Toolkit
 
@@ -38,6 +39,10 @@ def is_controller_supported(controller) -> tuple[bool, str]:
             if sys.platform != "darwin":
                 return False, "platform_not_supported"
             return True, ""
+        case "WlRoots":
+            if not sys.platform.startswith("linux"):
+                return False, "platform_not_supported"
+            return True, ""
         case "Gamepad":
             if sys.platform != "win32":
                 return False, "platform_not_supported"
@@ -56,7 +61,7 @@ def _record_identity(
 
 def _scan_device_address(device: dict[str, Any]) -> str | None:
     device_type = device.get("type")
-    if device_type in ("Adb", "PlayCover"):
+    if device_type in ("Adb", "PlayCover", "WlRoots"):
         return try_canonicalize_runtime_device_address(
             device_type, str(device.get("address", ""))
         )
@@ -140,6 +145,7 @@ class DeviceService:
                     "Win32",
                     "Gamepad",
                     "PlayCover",
+                    "WlRoots",
                 ):
                     continue
                 address = try_canonicalize_runtime_device_address(
@@ -320,7 +326,7 @@ class DeviceService:
                 }
             )
 
-        controller_order = ["Adb", "Win32", "Gamepad", "PlayCover"]
+        controller_order = ["Adb", "Win32", "Gamepad", "PlayCover", "WlRoots"]
         return sorted(
             capabilities,
             key=lambda item: (
@@ -335,6 +341,7 @@ class DeviceService:
         devices: list[dict[str, Any]] = []
         win32_seen: set[int] = set()
         gamepad_seen: set[int] = set()
+        wlroots_seen: set[str] = set()
 
         supported, _ = is_controller_supported(controller)
         if not supported:
@@ -387,6 +394,19 @@ class DeviceService:
                     )
             case "PlayCover":
                 return devices
+            case "WlRoots":
+                for device in Toolkit.find_desktop_windows():
+                    socket_path = device.class_name.strip()
+                    if not socket_path or socket_path in wlroots_seen:
+                        continue
+                    wlroots_seen.add(socket_path)
+                    devices.append(
+                        {
+                            "type": "WlRoots",
+                            "name": device.window_name,
+                            "address": socket_path,
+                        }
+                    )
             case "Gamepad":
                 assert controller.gamepad is not None
                 for device in Toolkit.find_desktop_windows():
@@ -496,12 +516,13 @@ class DeviceService:
 
         Args:
             controller_name: 控制器名称（来自 interface.json 的 controller name）
-            device_type: 设备类型 ("Adb", "Win32", "Gamepad", "PlayCover")
+            device_type: 设备类型 ("Adb", "Win32", "Gamepad", "PlayCover", "WlRoots")
             device_address: 设备地址（格式因类型而异）
                 - Adb: IP:PORT 地址，如 "127.0.0.1:5555"
                 - Win32: hWnd 的字符串形式，如 "123456"
                 - Gamepad: "hWnd|gamepad_type" 格式，如 "123456|1"
                 - PlayCover: IP:PORT 地址，如 "127.0.0.1:1717"
+                - WlRoots: Wayland socket 路径
 
         Returns:
             构造好的 DeviceModel 实例
@@ -561,6 +582,13 @@ class DeviceService:
                 address=device_address,
                 uuid="",
             )
+        elif device_type == "WlRoots":
+            return DeviceModel(
+                type="WlRoots",
+                controller_name=controller_name,
+                name=device_address,
+                address=device_address,
+            )
         else:
             raise ValueError(f"不支持的设备类型: {device_type}")
 
@@ -619,6 +647,16 @@ class DeviceService:
                 controller = PlayCoverController(
                     address=device_config.address or "127.0.0.1:1717",
                     uuid=device_config.uuid,
+                )
+                status = controller.post_connection().wait().succeeded
+            case "WlRoots":
+                use_win32_vk_code = bool(
+                    selected_controller.wlroots
+                    and selected_controller.wlroots.use_win32_vk_code
+                )
+                controller = WlRootsController(
+                    wlr_socket_path=device_config.address,
+                    use_win32_vk_code=use_win32_vk_code,
                 )
                 status = controller.post_connection().wait().succeeded
 

--- a/maa_worker/execution.py
+++ b/maa_worker/execution.py
@@ -7,6 +7,7 @@
 """
 
 import asyncio
+import copy
 import logging
 import sqlite3
 import uuid
@@ -456,6 +457,14 @@ async def _complete_run(
         )
         if not normalized_task_list:
             raise RuntimeError("任务列表为空")
+
+        global_values = (
+            state.settings.globalOptionValues if state.settings is not None else {}
+        ) or {}
+        for task_id in normalized_task_list:
+            per_task = normalized_task_options.setdefault(task_id, {})
+            for option_name, option_value in global_values.items():
+                per_task.setdefault(option_name, copy.deepcopy(option_value))
 
         # 3. PI pretask + 用户命令统一在 Controller 创建/连接前执行。
         # 已锁定且可复用的 Controller 无法重新满足“创建前”，此处仍保证在任务启动前执行。

--- a/maa_worker/execution.py
+++ b/maa_worker/execution.py
@@ -7,7 +7,6 @@
 """
 
 import asyncio
-import copy
 import logging
 import sqlite3
 import uuid
@@ -26,7 +25,10 @@ from models.scheduler import (
     StartConflict,
     TaskExecution,
 )
-from models.task_config import normalize_task_execution_payload
+from models.task_config import (
+    normalize_global_option_values,
+    normalize_task_execution_payload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -461,10 +463,10 @@ async def _complete_run(
         global_values = (
             state.settings.globalOptionValues if state.settings is not None else {}
         ) or {}
-        for task_id in normalized_task_list:
-            per_task = normalized_task_options.setdefault(task_id, {})
-            for option_name, option_value in global_values.items():
-                per_task.setdefault(option_name, copy.deepcopy(option_value))
+        normalized_global_options = normalize_global_option_values(
+            global_values,
+            worker.interface,
+        )
 
         # 3. PI pretask + 用户命令统一在 Controller 创建/连接前执行。
         # 已锁定且可复用的 Controller 无法重新满足“创建前”，此处仍保证在任务启动前执行。
@@ -481,6 +483,7 @@ async def _complete_run(
                     payload.resource_name,
                     normalized_task_options,
                     normalized_pre_tasks,
+                    global_options=normalized_global_options,
                 )
             )
         except PretaskStopped:
@@ -538,6 +541,7 @@ async def _complete_run(
             normalized_task_options,
             task_name=state.active_run.task_name if state.active_run else None,
             pre_tasks=normalized_pre_tasks,
+            global_options=normalized_global_options,
         ):
             raise RuntimeError("任务启动失败（可能已有任务在运行）")
         # 任务线程已启动：run_process 自行发出终端事件；标记以便停止/失败时不重复发、不误取消

--- a/maa_worker/hotkey.py
+++ b/maa_worker/hotkey.py
@@ -119,8 +119,15 @@ def hotkey_value_to_codes(
     value: str, controller_type: str | None
 ) -> tuple[int, int, int]:
     primary, modifiers = split_hotkey_combo(value)
+    unsupported_keys = {"META", "SUPER", "WIN", "CMD", "COMMAND"}
+    if primary.upper() in unsupported_keys or any(
+        modifier.upper() in unsupported_keys for modifier in modifiers
+    ):
+        raise ValueError("快捷键不支持 Meta/Command/Win 键")
+    if len(modifiers) > 2:
+        raise ValueError("快捷键最多支持两个修饰键")
     key_map = HOTKEY_KEY_MAP.get(controller_type or "", HOTKEY_KEY_MAP["Win32"])
-    modifier_codes = [key_map.get(modifier.upper(), 0) for modifier in modifiers[:2]]
+    modifier_codes = [key_map.get(modifier.upper(), 0) for modifier in modifiers]
     modifier_codes.extend([0] * (2 - len(modifier_codes)))
     return (
         key_map.get(primary.upper(), 0),

--- a/maa_worker/hotkey.py
+++ b/maa_worker/hotkey.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+
+def _letter_codes(values: list[int]) -> dict[str, int]:
+    return {chr(ord("A") + index): value for index, value in enumerate(values)}
+
+
+def _function_key_codes(values: list[int]) -> dict[str, int]:
+    return {f"F{index + 1}": value for index, value in enumerate(values)}
+
+
+HOTKEY_KEY_MAP: dict[str, dict[str, int]] = {
+    "Win32": {
+        "BACKSPACE": 0x08,
+        "TAB": 0x09,
+        "ENTER": 0x0D,
+        "SHIFT": 0x10,
+        "CTRL": 0x11,
+        "ALT": 0x12,
+        "ESC": 0x1B,
+        "SPACE": 0x20,
+        "PAGEUP": 0x21,
+        "PAGEDOWN": 0x22,
+        "END": 0x23,
+        "HOME": 0x24,
+        "LEFT": 0x25,
+        "UP": 0x26,
+        "RIGHT": 0x27,
+        "DOWN": 0x28,
+        "DELETE": 0x2E,
+        **{str(value): 0x30 + value for value in range(10)},
+        **_letter_codes(list(range(0x41, 0x5B))),
+        **_function_key_codes(list(range(0x70, 0x7C))),
+    },
+    "Adb": {
+        "BACKSPACE": 67,
+        "TAB": 61,
+        "ENTER": 66,
+        "SHIFT": 59,
+        "CTRL": 113,
+        "ALT": 57,
+        "SPACE": 62,
+        "ESC": 111,
+        "DELETE": 112,
+        "HOME": 3,
+        "END": 123,
+        "PAGEUP": 92,
+        "PAGEDOWN": 93,
+        "LEFT": 21,
+        "RIGHT": 22,
+        "UP": 19,
+        "DOWN": 20,
+        **{str(value): 7 + value for value in range(10)},
+        **_letter_codes(list(range(29, 55))),
+        **_function_key_codes(list(range(131, 143))),
+    },
+    "WlRoots": {
+        "BACKSPACE": 14,
+        "TAB": 15,
+        "ENTER": 28,
+        "SHIFT": 42,
+        "CTRL": 29,
+        "ALT": 56,
+        "SPACE": 57,
+        "ESC": 1,
+        "DELETE": 111,
+        "HOME": 102,
+        "END": 107,
+        "PAGEUP": 104,
+        "PAGEDOWN": 109,
+        "LEFT": 105,
+        "RIGHT": 106,
+        "UP": 103,
+        "DOWN": 108,
+        **dict(zip("0123456789", [11, 2, 3, 4, 5, 6, 7, 8, 9, 10], strict=True)),
+        **_letter_codes(
+            [
+                30,
+                48,
+                46,
+                32,
+                18,
+                33,
+                34,
+                35,
+                23,
+                36,
+                37,
+                38,
+                50,
+                49,
+                24,
+                25,
+                16,
+                19,
+                31,
+                20,
+                22,
+                47,
+                17,
+                45,
+                21,
+                44,
+            ]
+        ),
+        **_function_key_codes([*range(59, 69), 87, 88]),
+    },
+}
+
+
+def split_hotkey_combo(value: str) -> tuple[str, list[str]]:
+    parts = [part.strip() for part in value.split("+") if part.strip()]
+    if not parts:
+        return "", []
+    return parts[-1], parts[:-1]
+
+
+def hotkey_value_to_codes(
+    value: str, controller_type: str | None
+) -> tuple[int, int, int]:
+    primary, modifiers = split_hotkey_combo(value)
+    key_map = HOTKEY_KEY_MAP.get(controller_type or "", HOTKEY_KEY_MAP["Win32"])
+    modifier_codes = [key_map.get(modifier.upper(), 0) for modifier in modifiers[:2]]
+    modifier_codes.extend([0] * (2 - len(modifier_codes)))
+    return (
+        key_map.get(primary.upper(), 0),
+        modifier_codes[0],
+        modifier_codes[1],
+    )

--- a/maa_worker/pipeline_override.py
+++ b/maa_worker/pipeline_override.py
@@ -308,6 +308,13 @@ class PipelineOverrideService:
             controller_type = (
                 controller_definitions[0].type if controller_definitions else None
             )
+            if (
+                controller_definitions
+                and controller_type == "WlRoots"
+                and controller_definitions[0].wlroots
+                and controller_definitions[0].wlroots.use_win32_vk_code
+            ):
+                controller_type = "Win32"
             return self._deep_merge(
                 merged,
                 self._build_hotkey_override(
@@ -399,6 +406,7 @@ class PipelineOverrideService:
         self,
         task_name: str,
         options: dict[str, TaskOptionValue],
+        global_options: dict[str, TaskOptionValue] | None = None,
     ) -> PipelineOverride:
         task_definition = self._get_current_task_definition(task_name)
         if task_definition is None:
@@ -412,8 +420,15 @@ class PipelineOverrideService:
                 controller_option_names.extend(controller.option)
 
         merged = copy.deepcopy(task_definition.pipeline_override) or {}
+        merged = self._deep_merge(
+            merged,
+            self._build_option_group_override(
+                self.worker.interface.global_option or [],
+                global_options or {},
+                controller_names,
+            ),
+        )
         option_groups = [
-            self.worker.interface.global_option or [],
             resource_definition.option
             if resource_definition and resource_definition.option
             else [],

--- a/maa_worker/pipeline_override.py
+++ b/maa_worker/pipeline_override.py
@@ -2,6 +2,7 @@ import copy
 from typing import TYPE_CHECKING, cast
 
 import json_utils as json
+from maa_worker.hotkey import hotkey_value_to_codes
 from models.interface import PipelineOverride
 from models.scheduler import TaskOptionValue
 
@@ -221,6 +222,43 @@ class PipelineOverrideService:
             ),
         )
 
+    def _build_hotkey_override(
+        self,
+        option_name: str,
+        option,
+        options: dict[str, TaskOptionValue],
+        controller_type: str | None,
+    ) -> PipelineOverride:
+        if not option.pipeline_override or not option.hotkeys:
+            return {}
+
+        typed_replacements: dict[str, object] = {}
+        raw_option_value = options.get(option_name)
+        for field in option.hotkeys:
+            raw_text = field.default or ""
+            if isinstance(raw_option_value, dict):
+                field_value = raw_option_value.get(field.name)
+                if isinstance(field_value, str):
+                    raw_text = field_value
+
+            primary_code, modifier1_code, modifier2_code = hotkey_value_to_codes(
+                raw_text,
+                controller_type,
+            )
+            typed_replacements[f"{{{field.name}}}"] = primary_code
+            typed_replacements[f"{{{field.name}.primary}}"] = primary_code
+            typed_replacements[f"{{{field.name}.modifier1}}"] = modifier1_code
+            typed_replacements[f"{{{field.name}.modifier2}}"] = modifier2_code
+
+        return cast(
+            PipelineOverride,
+            self._substitute_placeholders(
+                option.pipeline_override,
+                typed_replacements,
+                {},
+            ),
+        )
+
     def _build_scan_select_override(
         self,
         option_name: str,
@@ -263,6 +301,23 @@ class PipelineOverrideService:
         next_lineage = {*lineage, option_name}
 
         merged: PipelineOverride = {}
+        if option.type == "hotkey":
+            controller_definitions = (
+                self.worker.device.get_active_controller_definitions()
+            )
+            controller_type = (
+                controller_definitions[0].type if controller_definitions else None
+            )
+            return self._deep_merge(
+                merged,
+                self._build_hotkey_override(
+                    option_name,
+                    option,
+                    options,
+                    controller_type,
+                ),
+            )
+
         if option.type == "input":
             return self._deep_merge(
                 merged,

--- a/maa_worker/pretask_service.py
+++ b/maa_worker/pretask_service.py
@@ -35,6 +35,7 @@ class PretaskService:
         resource_name: str,
         task_options: TaskOptionsByTask,
         user_pre_tasks: list[PreTaskCommand],
+        global_options: dict[str, TaskOptionValue] | None = None,
     ) -> None:
         """Run matching PI pretasks first, then enabled user shell commands."""
         raw_pretasks = self.worker.interface.pretask
@@ -54,7 +55,11 @@ class PretaskService:
             display_name = pretask.label or pretask.name or pretask.exec
             argv = [pretask.exec, *(pretask.args or [])]
             if pretask.option:
-                option_values = self._resolve_option_values(pretask, task_options)
+                option_values = self._resolve_option_values(
+                    pretask,
+                    task_options,
+                    global_options or {},
+                )
                 argv.append(
                     json.dumps(
                         option_values,
@@ -83,6 +88,7 @@ class PretaskService:
         self,
         pretask: Pretask,
         task_options: TaskOptionsByTask,
+        global_options: dict[str, TaskOptionValue],
     ) -> dict[str, TaskOptionValue]:
         option_map = self.worker.interface.option or {}
         values: dict[str, TaskOptionValue] = {}
@@ -90,6 +96,10 @@ class PretaskService:
             resolved_value = self._find_option_value(task_options, option_name)
             if resolved_value is not None:
                 values[option_name] = resolved_value
+                continue
+            global_value = global_options.get(option_name)
+            if global_value is not None:
+                values[option_name] = global_value
                 continue
             option = option_map.get(option_name)
             values[option_name] = (

--- a/maa_worker/task_service.py
+++ b/maa_worker/task_service.py
@@ -58,6 +58,7 @@ class TaskService:
         options: TaskOptionsByTask,
         task_name: str | None = None,
         pre_tasks: list[PreTaskCommand] | None = None,
+        global_options: dict[str, TaskOptionValue] | None = None,
     ) -> bool:
         self.worker.task_state.last_error = None
         if not self.worker.device_state.connected:
@@ -143,6 +144,7 @@ class TaskService:
                     filtered_task_list,
                     copy.deepcopy(cleaned_options),
                     pre_tasks or [],
+                    copy.deepcopy(global_options or {}),
                 ),
                 daemon=True,
             )
@@ -164,6 +166,7 @@ class TaskService:
         task_list: list[str],
         options: TaskOptionsByTask,
         pre_tasks: list[PreTaskCommand] | None = None,
+        global_options: dict[str, TaskOptionValue] | None = None,
     ):
         state = self.worker.task_state
         state.pre_tasks = pre_tasks or []
@@ -181,6 +184,7 @@ class TaskService:
                 pipeline_override = self.worker.pipeline.build_task_pipeline_override(
                     task,
                     options.get(task, {}),
+                    global_options or {},
                 )
                 if pipeline_override:
                     task_result = self.worker.tasker.post_task(task, pipeline_override)

--- a/models/api.py
+++ b/models/api.py
@@ -39,6 +39,10 @@ class DeviceModel(BaseModel):
                 raise ValueError("Adb address must not be empty")
         elif self.type == "PlayCover":
             self.address = canonicalize_ipv4_port(self.address)
+        elif self.type == "WlRoots":
+            self.address = self.address.strip()
+            if not self.address:
+                raise ValueError("WlRoots socket path must not be empty")
         elif self.type == "Win32":
             if self.hWnd <= 0:
                 raise ValueError("Win32 hWnd must be positive")

--- a/models/device_address.py
+++ b/models/device_address.py
@@ -2,14 +2,14 @@
 
 Single source of truth for device address validation and normalization.
 Custom (user-entered) addresses are strict; runtime (scanned) addresses
-are lenient for Adb (USB serials) but strict for PlayCover/Win32/Gamepad.
+are lenient for Adb (USB serials) but strict for PlayCover/Win32/Gamepad/WlRoots.
 """
 
 import re
 from ipaddress import IPv4Address
 from typing import Literal
 
-DeviceType = Literal["Adb", "Win32", "Gamepad", "PlayCover"]
+DeviceType = Literal["Adb", "Win32", "Gamepad", "PlayCover", "WlRoots"]
 
 _IPV4_PORT_PATTERN = re.compile(r"^([^:]+):(\d+)$")
 
@@ -46,12 +46,17 @@ def canonicalize_custom_device_address(device_type: str, address: str) -> str:
     """Validate and canonicalize a custom (user-entered) device address.
 
     Adb/PlayCover: must be IPv4:port.
+    WlRoots: non-empty Wayland socket path.
     Win32: positive integer hWnd.
     Gamepad: hWnd|type where type is 0 or 1.
     """
     text = str(address).strip()
     if device_type in ("Adb", "PlayCover"):
         return canonicalize_ipv4_port(text)
+    if device_type == "WlRoots":
+        if not text:
+            raise ValueError("WlRoots socket path must not be empty")
+        return text
     if device_type == "Win32":
         if not text.isdigit() or int(text) <= 0:
             raise ValueError("Win32 address must be a positive integer hWnd")
@@ -79,6 +84,7 @@ def canonicalize_runtime_device_address(device_type: str, address: str) -> str:
     PlayCover: must be IPv4:port.
     Win32: positive integer hWnd.
     Gamepad: hWnd|type where type is 0 or 1.
+    WlRoots: non-empty Wayland socket path.
     """
     text = str(address).strip()
     if device_type == "Adb":
@@ -87,6 +93,10 @@ def canonicalize_runtime_device_address(device_type: str, address: str) -> str:
         return text
     if device_type == "PlayCover":
         return canonicalize_ipv4_port(text)
+    if device_type == "WlRoots":
+        if not text:
+            raise ValueError("WlRoots socket path must not be empty")
+        return text
     if device_type == "Win32":
         if not text.isdigit() or int(text) <= 0:
             raise ValueError("Win32 address must be a positive integer hWnd")

--- a/models/interface.py
+++ b/models/interface.py
@@ -13,6 +13,7 @@ from pydantic import (
 DocumentContent = str | list[str]
 PipelineOverride = dict[str, Any]
 PresetOptionValue = str | list[str] | dict[str, str]
+_UNSUPPORTED_HOTKEY_KEYS = {"META", "SUPER", "WIN", "CMD", "COMMAND"}
 
 
 def validate_regex(v: Any, info: ValidationInfo) -> Any:
@@ -159,6 +160,12 @@ class MacOSController(BaseModel):
         return validate_regex(v, info)
 
 
+class WlRootsController(BaseModel):
+    """WlRoots 控制器配置（仅 Linux）"""
+
+    use_win32_vk_code: bool | None = False
+
+
 class GamepadController(BaseModel):
     """虚拟游戏手柄控制器配置（仅 Windows）"""
 
@@ -211,7 +218,7 @@ class Controller(BaseModel):
     label: str | None = None
     description: str | None = None
     icon: str | None = None
-    type: Literal["Adb", "Win32", "MacOS", "PlayCover", "Gamepad"]
+    type: Literal["Adb", "Win32", "MacOS", "PlayCover", "WlRoots", "Gamepad"]
     display_short_side: int | None = 720
     display_long_side: int | None = None
     display_raw: bool | None = False
@@ -222,6 +229,7 @@ class Controller(BaseModel):
     win32: Win32Controller | None = None
     macos: MacOSController | None = None
     playcover: PlayCoverController | None = None
+    wlroots: WlRootsController | None = None
     gamepad: GamepadController | None = None
 
     @model_validator(mode="after")
@@ -328,6 +336,16 @@ class HotkeyCase(BaseModel):
     label: str | None = None
     description: str | None = None
     default: str | None = None
+
+    @field_validator("default")
+    @classmethod
+    def check_modifier_count(cls, value: str | None):
+        parts = [part.strip() for part in (value or "").split("+") if part.strip()]
+        if len(parts) > 3:
+            raise ValueError("快捷键最多支持两个修饰键")
+        if any(part.upper() in _UNSUPPORTED_HOTKEY_KEYS for part in parts):
+            raise ValueError("快捷键不支持 Meta/Command/Win 键")
+        return value
 
 
 class Option(BaseModel):

--- a/models/interface.py
+++ b/models/interface.py
@@ -295,6 +295,15 @@ class Group(BaseModel):
     default_expand: bool | None = True
 
 
+class SettingSection(BaseModel):
+    name: str
+    label: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    option: list[str] | None = None
+    default_expand: bool | None = True
+
+
 class OptionCase(BaseModel):
     name: str
     label: str | None = None
@@ -314,8 +323,17 @@ class InputCase(BaseModel):
     pattern_msg: str | None = None
 
 
+class HotkeyCase(BaseModel):
+    name: str
+    label: str | None = None
+    description: str | None = None
+    default: str | None = None
+
+
 class Option(BaseModel):
-    type: Literal["select", "input", "checkbox", "switch", "scan_select"] = "select"
+    type: Literal["select", "input", "checkbox", "switch", "scan_select", "hotkey"] = (
+        "select"
+    )
     label: str | None = None
     description: str | None = None
     icon: str | None = None
@@ -323,6 +341,7 @@ class Option(BaseModel):
     resource: list[str] | None = None
     cases: list[OptionCase] | None = None
     inputs: list[InputCase] | None = None
+    hotkeys: list[HotkeyCase] | None = None
     scan_dir: str | None = None
     scan_filter: str | None = None
     pipeline_override: PipelineOverride | None = None
@@ -348,6 +367,8 @@ class Option(BaseModel):
                 )
         if self.type == "input" and not self.inputs:
             raise ValueError("当 type 为 input 时，inputs 不能为空")
+        if self.type == "hotkey" and not self.hotkeys:
+            raise ValueError("当 type 为 hotkey 时，hotkeys 不能为空")
         if self.type == "scan_select":
             if not self.scan_dir:
                 raise ValueError("当 type 为 scan_select 时，scan_dir 不能为空")
@@ -407,6 +428,7 @@ class InterfaceModel(BaseModel):
     pretask: Pretask | list[Pretask] | None = None
     option: dict[str, Option] | None = None
     global_option: list[str] | None = None
+    setting: list[SettingSection] | None = None
     import_: list[str] | None = Field(None, alias="import")
     preset: list[Preset] | None = None
 

--- a/models/interface_loader.py
+++ b/models/interface_loader.py
@@ -6,7 +6,15 @@ from typing import Any
 import json_utils as json
 from models.interface import InterfaceModel, Option, OptionCase
 
-IMPORTABLE_KEYS = {"task", "option", "preset", "pretask", "import"}
+IMPORTABLE_KEYS = {
+    "task",
+    "option",
+    "preset",
+    "pretask",
+    "import",
+    "global_option",
+    "setting",
+}
 
 # pathlib.Path is OS-aware: on POSIX it does not recognize Windows drive
 # letters (e.g. "C:/windows" parses as a relative path). Detect them
@@ -55,7 +63,8 @@ def _validate_importable_fragment(data: dict[str, Any], source_path: Path) -> No
     invalid_keys = sorted(set(data) - IMPORTABLE_KEYS)
     if invalid_keys:
         raise InterfaceLoadError(
-            f"导入文件只允许包含 task、option、preset、pretask、import 字段: {source_path}，"
+            "导入文件只允许包含 task、option、preset、pretask、import、"
+            f"global_option、setting 字段: {source_path}，"
             f"发现非法字段 {', '.join(invalid_keys)}"
         )
 
@@ -180,6 +189,19 @@ def _merge_fragment_sections(
     if presets:
         target.setdefault("preset", [])
         target["preset"].extend(copy.deepcopy(presets))
+
+    global_options = fragment.get("global_option")
+    if global_options:
+        target_global_options = target.setdefault("global_option", [])
+        for option_name in global_options:
+            if option_name not in target_global_options:
+                target_global_options.append(copy.deepcopy(option_name))
+
+    settings = fragment.get("setting")
+    if settings:
+        target.setdefault("setting", [])
+        target["setting"].extend(copy.deepcopy(settings))
+
     _merge_pretasks(target, fragment)
 
 
@@ -418,6 +440,18 @@ def _validate_preset_option_value(
             if not isinstance(input_value, str):
                 raise InterfaceLoadError(f"{location}.{input_name} 必须是字符串")
 
+    if option.type == "hotkey":
+        if not isinstance(value, dict):
+            raise InterfaceLoadError(f"{location} 必须是对象")
+        hotkey_names = {item.name for item in option.hotkeys or []}
+        for hotkey_name, hotkey_value in value.items():
+            if hotkey_name not in hotkey_names:
+                raise InterfaceLoadError(
+                    f"{location} 引用了不存在的快捷键项: {hotkey_name}"
+                )
+            if not isinstance(hotkey_value, str):
+                raise InterfaceLoadError(f"{location}.{hotkey_name} 必须是字符串")
+
 
 def _validate_presets(interface_model: InterfaceModel) -> None:
     presets = interface_model.preset or []
@@ -463,6 +497,22 @@ def _validate_presets(interface_model: InterfaceModel) -> None:
                     option_name,
                     option,
                     option_value,
+                )
+
+
+def _validate_setting_sections(interface_model: InterfaceModel) -> None:
+    option_map = interface_model.option or {}
+    seen_names: set[str] = set()
+
+    for section in interface_model.setting or []:
+        if section.name in seen_names:
+            raise InterfaceLoadError(f"setting 中存在重复分区: {section.name}")
+        seen_names.add(section.name)
+
+        for option_name in section.option or []:
+            if option_name not in option_map:
+                raise InterfaceLoadError(
+                    f"setting[{section.name}] 引用了不存在的选项: {option_name}"
                 )
 
 
@@ -624,6 +674,7 @@ def load_interface_model(base_dir: str | Path) -> InterfaceModel:
         _validate_task_context_constraints(interface_model)
         _validate_pretasks(interface_model)
         _validate_presets(interface_model)
+        _validate_setting_sections(interface_model)
         return interface_model
     except Exception as exc:
         raise InterfaceLoadError(f"校验 interface 配置失败: {exc}") from exc

--- a/models/scheduler.py
+++ b/models/scheduler.py
@@ -132,7 +132,7 @@ class ScheduledTaskDeviceConfig(BaseModel):
     """定时任务设备配置"""
 
     controller_name: str = Field(..., description="控制器名称")
-    device_type: Literal["Adb", "Win32", "Gamepad", "PlayCover"] = Field(
+    device_type: Literal["Adb", "Win32", "Gamepad", "PlayCover", "WlRoots"] = Field(
         ..., description="设备类型"
     )
     device_address: str = Field(..., description="设备地址")

--- a/models/settings.py
+++ b/models/settings.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from models.device_address import DeviceType
+from models.scheduler import TaskOptionValue
 
 
 def _normalize_str(value: Any) -> str:
@@ -200,3 +201,4 @@ class SettingsModel(BaseModel):
     runtime: Runtime = Runtime()
     about: About = About()
     panel: Panel = Panel()
+    globalOptionValues: dict[str, TaskOptionValue] = Field(default_factory=dict)

--- a/models/task_config.py
+++ b/models/task_config.py
@@ -486,6 +486,14 @@ def _build_option_defaults(
                 input_defaults[input_case.name] = input_case.default or ""
             defaults[option_name] = input_defaults
             value_types[option_name] = "object"
+            continue
+
+        if option.type == "hotkey":
+            defaults[option_name] = {
+                hotkey_case.name: hotkey_case.default or ""
+                for hotkey_case in option.hotkeys or []
+            }
+            value_types[option_name] = "object"
 
     return defaults, value_types
 
@@ -538,7 +546,7 @@ def _normalize_options_for_task(
 
         if expected_type == "object" and isinstance(option_value, dict):
             option = option_map.get(option_key)
-            if option is None or option.type != "input":
+            if option is None or option.type not in {"input", "hotkey"}:
                 continue
 
             existing_value = normalized_options.get(option_key)
@@ -552,10 +560,11 @@ def _normalize_options_for_task(
                 else {}
             )
 
-            for input_case in option.inputs or []:
-                input_value = option_value.get(input_case.name)
-                if isinstance(input_value, str):
-                    normalized_input[input_case.name] = input_value
+            fields = option.inputs if option.type == "input" else option.hotkeys
+            for field in fields or []:
+                field_value = option_value.get(field.name)
+                if isinstance(field_value, str):
+                    normalized_input[field.name] = field_value
 
             normalized_options[option_key] = normalized_input
 
@@ -584,7 +593,7 @@ def _apply_preset_option_value(
     if option is None:
         return
 
-    if option.type == "input":
+    if option.type in {"input", "hotkey"}:
         if not isinstance(value, dict):
             return
 
@@ -599,10 +608,11 @@ def _apply_preset_option_value(
             else {}
         )
 
-        for input_case in option.inputs or []:
-            input_value = value.get(input_case.name)
-            if isinstance(input_value, str):
-                normalized_input[input_case.name] = input_value
+        fields = option.inputs if option.type == "input" else option.hotkeys
+        for field in fields or []:
+            field_value = value.get(field.name)
+            if isinstance(field_value, str):
+                normalized_input[field.name] = field_value
 
         target_options[option_name] = normalized_input
         return

--- a/models/task_config.py
+++ b/models/task_config.py
@@ -175,6 +175,27 @@ def normalize_task_options_by_task(
     return normalized
 
 
+def normalize_global_option_values(
+    raw_global_options: dict[str, Any] | None,
+    interface_model: InterfaceModel,
+) -> dict[str, TaskOptionValue]:
+    all_options = interface_model.option or {}
+    option_map = {
+        option_name: all_options[option_name]
+        for option_name in (interface_model.global_option or [])
+        if option_name in all_options
+    }
+    defaults, value_types = _build_option_defaults(option_map)
+    case_name_sets = _build_option_case_name_sets(option_map)
+    return _normalize_options_for_task(
+        raw_global_options,
+        option_map,
+        defaults,
+        value_types,
+        case_name_sets,
+    )
+
+
 def normalize_task_execution_payload(
     raw_task_list: Any,
     raw_task_options: Any,
@@ -564,6 +585,10 @@ def _normalize_options_for_task(
             for field in fields or []:
                 field_value = option_value.get(field.name)
                 if isinstance(field_value, str):
+                    if option.type == "hotkey" and not _hotkey_value_supported(
+                        field_value
+                    ):
+                        continue
                     normalized_input[field.name] = field_value
 
             normalized_options[option_key] = normalized_input
@@ -612,6 +637,8 @@ def _apply_preset_option_value(
         for field in fields or []:
             field_value = value.get(field.name)
             if isinstance(field_value, str):
+                if option.type == "hotkey" and not _hotkey_value_supported(field_value):
+                    continue
                 normalized_input[field.name] = field_value
 
         target_options[option_name] = normalized_input
@@ -626,3 +653,11 @@ def _apply_preset_option_value(
 
     if isinstance(value, str):
         target_options[option_name] = value
+
+
+def _hotkey_value_supported(value: str) -> bool:
+    parts = [part.strip() for part in value.split("+") if part.strip()]
+    unsupported_keys = {"META", "SUPER", "WIN", "CMD", "COMMAND"}
+    return len(parts) <= 3 and not any(
+        part.upper() in unsupported_keys for part in parts
+    )

--- a/tests/unit/test_custom_devices.py
+++ b/tests/unit/test_custom_devices.py
@@ -10,18 +10,27 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
+from maa.toolkit import Toolkit
 
 from app_state import WorkerContext
 from maa_worker.device_service import (
     DeviceService,
     custom_record_to_device,
+    is_controller_supported,
 )
 from models.api import CustomDeviceCreate
 from models.device_address import canonicalize_custom_device_address
 
 
 def _controller(name: str, type_: str) -> SimpleNamespace:
-    return SimpleNamespace(name=name, type=type_, label=name, win32=None, gamepad=None)
+    return SimpleNamespace(
+        name=name,
+        type=type_,
+        label=name,
+        win32=None,
+        gamepad=None,
+        wlroots=None,
+    )
 
 
 class _FakeWorker:
@@ -83,6 +92,14 @@ class TestCanonicalizeCustomAddress:
             canonicalize_custom_device_address("PlayCover", " 127.0.0.1:1717 ")
             == "127.0.0.1:1717"
         )
+
+    def test_wlroots_socket_path_trimmed(self):
+        assert (
+            canonicalize_custom_device_address("WlRoots", " /run/user/1000/wayland-1 ")
+            == "/run/user/1000/wayland-1"
+        )
+        with pytest.raises(ValueError):
+            canonicalize_custom_device_address("WlRoots", "   ")
 
     def test_adb_empty_rejected(self):
         with pytest.raises(ValueError):
@@ -164,6 +181,124 @@ class TestCustomRecordToDevice:
             }
         )
         assert device == {"type": "PlayCover", "address": "127.0.0.1:1717"}
+
+    def test_wlroots_address(self):
+        device = custom_record_to_device(
+            {
+                "controller_name": "WlRootsController",
+                "type": "WlRoots",
+                "address": "/run/user/1000/wayland-1",
+            }
+        )
+        assert device == {
+            "type": "WlRoots",
+            "address": "/run/user/1000/wayland-1",
+        }
+
+
+class TestWlRootsSupport:
+    def test_platform_capability(self):
+        controller = _controller("WlRootsController", "WlRoots")
+        with patch("maa_worker.device_service.sys.platform", "linux"):
+            assert is_controller_supported(controller) == (True, "")
+        with patch("maa_worker.device_service.sys.platform", "win32"):
+            assert is_controller_supported(controller) == (
+                False,
+                "platform_not_supported",
+            )
+
+    def test_scans_wayland_socket_paths(self, app_root: Path):
+        controller = _controller("WlRootsController", "WlRoots")
+        service = DeviceService(_FakeWorker(app_root, [controller]))  # type: ignore[arg-type]
+        scanned = [
+            SimpleNamespace(
+                class_name="/run/user/1000/wayland-1",
+                window_name="Wayland compositor",
+            ),
+            SimpleNamespace(
+                class_name="/run/user/1000/wayland-1",
+                window_name="duplicate",
+            ),
+        ]
+
+        with (
+            patch("maa_worker.device_service.sys.platform", "linux"),
+            patch.object(Toolkit, "find_desktop_windows", return_value=scanned),
+        ):
+            devices = service._find_devices_for_controller(controller)
+
+        assert devices == [
+            {
+                "type": "WlRoots",
+                "name": "Wayland compositor",
+                "address": "/run/user/1000/wayland-1",
+            }
+        ]
+
+    def test_builds_wlroots_device_model(self):
+        model = DeviceService.build_device_model_from_config(
+            "WlRootsController",
+            "WlRoots",
+            "/run/user/1000/wayland-1",
+        )
+
+        assert model.type == "WlRoots"
+        assert model.address == "/run/user/1000/wayland-1"
+
+    def test_connect_uses_socket_path_and_keycode_mode(self, app_root: Path):
+        captured: dict[str, Any] = {}
+
+        class _FakeWlRootsController:
+            connected = True
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            @staticmethod
+            def post_connection():
+                return SimpleNamespace(
+                    wait=lambda: SimpleNamespace(succeeded=True),
+                )
+
+        controller = _controller("WlRootsController", "WlRoots")
+        controller.wlroots = SimpleNamespace(use_win32_vk_code=True)
+        worker = _FakeWorker(app_root, [controller])
+        worker.device_state = SimpleNamespace(
+            configuration_locked=False,
+            connected=False,
+            controller=None,
+            controller_name=None,
+            controller_type=None,
+            current_resource_name=None,
+            last_device_error=None,
+        )
+        worker.events = SimpleNamespace(
+            send_log=lambda _message: None,
+            show_system_notification=lambda _title, _message: None,
+        )
+        worker.tasker = SimpleNamespace(bind=lambda _resource, _controller: True)
+        worker.resource = object()
+        worker.interface.title = "MWU"
+
+        model = DeviceService.build_device_model_from_config(
+            "WlRootsController",
+            "WlRoots",
+            "/run/user/1000/wayland-1",
+        )
+        with (
+            patch(
+                "maa_worker.device_service.WlRootsController",
+                _FakeWlRootsController,
+            ),
+            patch("maa_worker.device_service.time.sleep"),
+        ):
+            connected = DeviceService(worker).connect(model)  # type: ignore[arg-type]
+
+        assert connected is True
+        assert captured == {
+            "wlr_socket_path": "/run/user/1000/wayland-1",
+            "use_win32_vk_code": True,
+        }
 
 
 class TestCustomDevicePersistence:

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -23,6 +23,7 @@ from maa_worker.execution import (
     submit_scheduled,
 )
 from maa_worker.pretask_service import PretaskError, PretaskStopped
+from models.interface import Option, OptionCase
 from models.scheduler import (
     CronTriggerConfig,
     ManualStartPayload,
@@ -85,6 +86,7 @@ class _FakeInterface:
     def __init__(self, entries: list[str]):
         self.task = [SimpleNamespace(entry=e, option=[]) for e in entries]
         self.option = {}
+        self.global_option = []
         self.pretask = []
 
 
@@ -94,9 +96,18 @@ class _FakeTaskService:
         self.called = False
         self.block: threading.Event | None = None
         self._task_state = task_state
+        self.global_options = {}
 
-    def start(self, task_list, options, task_name=None, pre_tasks=None):
+    def start(
+        self,
+        task_list,
+        options,
+        task_name=None,
+        pre_tasks=None,
+        global_options=None,
+    ):
         self.called = True
+        self.global_options = global_options or {}
         if self.block is not None:
             # 阻塞至测试放行，模拟任务长时间占槽
             self.block.wait(timeout=5)
@@ -110,8 +121,16 @@ class _FakeTaskService:
 
 
 class _FakeSuccessfulTaskService(_FakeTaskService):
-    def start(self, task_list, options, task_name=None, pre_tasks=None):
+    def start(
+        self,
+        task_list,
+        options,
+        task_name=None,
+        pre_tasks=None,
+        global_options=None,
+    ):
         self.called = True
+        self.global_options = global_options or {}
         if self._task_state is not None:
             self._task_state.running = True
             self._task_state.last_status = "success"
@@ -125,16 +144,29 @@ class _FakePretaskService:
         task_state: "_FakeTaskState | None" = None,
         ordering: list[str] | None = None,
     ):
-        self.calls: list[tuple[str, str, dict, list]] = []
+        self.calls: list[tuple[str, str, dict, list, dict]] = []
         self.stop_flags: list[bool] = []
         self.error: PretaskError | None = None
         self.set_stop_flag_on_error = False
         self._task_state = task_state
         self._ordering = ordering
 
-    def run_all(self, controller_name, resource_name, task_options, user_pre_tasks):
+    def run_all(
+        self,
+        controller_name,
+        resource_name,
+        task_options,
+        user_pre_tasks,
+        global_options=None,
+    ):
         self.calls.append(
-            (controller_name, resource_name, task_options, user_pre_tasks)
+            (
+                controller_name,
+                resource_name,
+                task_options,
+                user_pre_tasks,
+                global_options or {},
+            )
         )
         self.stop_flags.append(
             self._task_state.stop_flag if self._task_state is not None else False
@@ -377,8 +409,16 @@ class TestSubmitManual:
         worker = _FakeWorker(start_result=True, ready=True)
 
         class _SuccessTaskService(_FakeTaskService):
-            def start(self, task_list, options, task_name=None, pre_tasks=None):
+            def start(
+                self,
+                task_list,
+                options,
+                task_name=None,
+                pre_tasks=None,
+                global_options=None,
+            ):
                 self.called = True
+                self.global_options = global_options or {}
                 # 模拟一次成功的手动运行：start 内部完成整个生命周期
                 self._task_state.running = True
                 self._task_state.last_status = "success"
@@ -550,7 +590,9 @@ class TestPretaskAdmission:
         assert admission.accepted is True
         await _await_active_task(state)
 
-        assert worker.pretasks.calls == [("AdbController", "main", {"Startup": {}}, [])]
+        assert worker.pretasks.calls == [
+            ("AdbController", "main", {"Startup": {}}, [], {})
+        ]
         assert worker.tasks.called is False
         row = list_executions(state.scheduler_db_path)[0]
         assert row.id == admission.run_id
@@ -619,12 +661,15 @@ class TestPretaskAdmission:
         assert admission.accepted is True
         await _await_active_task(state)
 
-        controller, resource, options, pre_tasks = worker.pretasks.calls[0]
+        controller, resource, options, pre_tasks, global_options = (
+            worker.pretasks.calls[0]
+        )
         assert (controller, resource) == ("AdbController", "main")
         assert list(options) == ["Startup"]
         assert [p.command for p in pre_tasks] == ["echo ok"]
+        assert global_options == {}
 
-    async def test_global_option_values_reach_pretask_for_each_selected_task(
+    async def test_global_option_values_reach_pretask_and_task_pipeline_separately(
         self, state: AppState
     ):
         worker = _FakeWorker(start_result=True, ready=True)
@@ -635,6 +680,14 @@ class TestPretaskAdmission:
             SimpleNamespace(entry="Startup", option=[]),
             SimpleNamespace(entry="Second", option=[]),
         ]
+        worker.interface.option = {
+            "global_setting": Option(
+                type="select",
+                cases=[OptionCase(name="default"), OptionCase(name="from-settings")],
+                default_case="default",
+            )
+        }
+        worker.interface.global_option = ["global_setting"]
         state.settings = SettingsModel(
             globalOptionValues={"global_setting": "from-settings"}
         )
@@ -647,11 +700,9 @@ class TestPretaskAdmission:
         await _await_active_task(state)
 
         assert len(worker.pretasks.calls) == 1
-        options = worker.pretasks.calls[0][2]
-        assert options == {
-            "Startup": {"global_setting": "from-settings"},
-            "Second": {"global_setting": "from-settings"},
-        }
+        assert worker.pretasks.calls[0][2] == {"Startup": {}, "Second": {}}
+        assert worker.pretasks.calls[0][4] == {"global_setting": "from-settings"}
+        assert worker.tasks.global_options == {"global_setting": "from-settings"}
 
     async def test_pretask_runs_before_device_connection(
         self, state: AppState, monkeypatch
@@ -671,7 +722,9 @@ class TestPretaskAdmission:
         assert admission.accepted is True
         await _await_active_task(state)
 
-        assert worker.pretasks.calls == [("AdbController", "main", {"Startup": {}}, [])]
+        assert worker.pretasks.calls == [
+            ("AdbController", "main", {"Startup": {}}, [], {})
+        ]
         assert ordering == ["pretask", "connect"]
         row = list_executions(state.scheduler_db_path)[0]
         assert row.id == admission.run_id

--- a/tests/unit/test_execution.py
+++ b/tests/unit/test_execution.py
@@ -31,6 +31,7 @@ from models.scheduler import (
     ScheduledTaskDeviceConfig,
     TaskExecution,
 )
+from models.settings import SettingsModel
 
 
 def make_payload(task_name: str = "Startup") -> ManualStartPayload:
@@ -622,6 +623,35 @@ class TestPretaskAdmission:
         assert (controller, resource) == ("AdbController", "main")
         assert list(options) == ["Startup"]
         assert [p.command for p in pre_tasks] == ["echo ok"]
+
+    async def test_global_option_values_reach_pretask_for_each_selected_task(
+        self, state: AppState
+    ):
+        worker = _FakeWorker(start_result=True, ready=True)
+        worker.tasks = _FakeSuccessfulTaskService(
+            result=True, task_state=worker.task_state
+        )
+        worker.interface.task = [
+            SimpleNamespace(entry="Startup", option=[]),
+            SimpleNamespace(entry="Second", option=[]),
+        ]
+        state.settings = SettingsModel(
+            globalOptionValues={"global_setting": "from-settings"}
+        )
+        state.worker = worker
+
+        payload = make_payload()
+        payload.task_list = ["Startup", "Second"]
+        admission = await submit_manual(state, payload)
+        assert admission.accepted is True
+        await _await_active_task(state)
+
+        assert len(worker.pretasks.calls) == 1
+        options = worker.pretasks.calls[0][2]
+        assert options == {
+            "Startup": {"global_setting": "from-settings"},
+            "Second": {"global_setting": "from-settings"},
+        }
 
     async def test_pretask_runs_before_device_connection(
         self, state: AppState, monkeypatch

--- a/tests/unit/test_hotkey.py
+++ b/tests/unit/test_hotkey.py
@@ -6,7 +6,13 @@ import pytest
 
 from maa_worker.hotkey import hotkey_value_to_codes, split_hotkey_combo
 from maa_worker.pipeline_override import PipelineOverrideService
-from models.interface import Controller, HotkeyCase, Option
+from models.interface import (
+    Controller,
+    HotkeyCase,
+    Option,
+    OptionCase,
+    WlRootsController,
+)
 
 
 class TestSplitHotkeyCombo:
@@ -41,6 +47,15 @@ class TestHotkeyValueToCodes:
         assert hotkey_value_to_codes("ALT+Unknown", "Win32") == (0, 0x12, 0)
         assert hotkey_value_to_codes("", "Win32") == (0, 0, 0)
 
+    def test_rejects_more_than_two_modifiers(self):
+        with pytest.raises(ValueError, match="最多支持两个修饰键"):
+            hotkey_value_to_codes("Ctrl+Alt+Shift+A", "Win32")
+
+    @pytest.mark.parametrize("value", ["Meta+A", "Command+A", "Win+A", "Super+A"])
+    def test_rejects_meta_aliases(self, value):
+        with pytest.raises(ValueError, match="不支持 Meta/Command/Win"):
+            hotkey_value_to_codes(value, "Win32")
+
 
 class TestPipelineOverrideHotkey:
     def test_replaces_modifier_and_primary_placeholders_with_integers(self):
@@ -72,3 +87,69 @@ class TestPipelineOverrideHotkey:
         )
 
         assert override == {"key": [0x12, 0x41]}
+
+    def test_wlroots_can_emit_win32_virtual_key_codes(self):
+        option = Option(
+            type="hotkey",
+            hotkeys=[HotkeyCase(name="FightCombo")],
+            pipeline_override={"key": "{FightCombo.primary}"},
+        )
+        worker = SimpleNamespace(
+            interface=SimpleNamespace(option={"K": option}),
+            device=SimpleNamespace(
+                get_active_controller_definitions=lambda: [
+                    Controller(
+                        name="wlr",
+                        type="WlRoots",
+                        wlroots=WlRootsController(use_win32_vk_code=True),
+                    )
+                ]
+            ),
+            device_state=SimpleNamespace(current_resource_name=None),
+        )
+
+        override = PipelineOverrideService(worker)._build_option_override(
+            "K",
+            {"K": {"FightCombo": "A"}},
+            set(),
+        )
+
+        assert override == {"key": 0x41}
+
+
+def test_saved_global_value_is_not_shadowed_by_task_default():
+    global_option = Option(
+        type="select",
+        cases=[
+            OptionCase(name="default", pipeline_override={"Node": {"mode": "default"}}),
+            OptionCase(name="saved", pipeline_override={"Node": {"mode": "saved"}}),
+        ],
+        default_case="default",
+    )
+    worker = SimpleNamespace(
+        interface=SimpleNamespace(
+            option={"GlobalMode": global_option},
+            global_option=["GlobalMode"],
+            task=[
+                SimpleNamespace(
+                    entry="Task",
+                    pipeline_override={},
+                    option=[],
+                )
+            ],
+        ),
+        device=SimpleNamespace(
+            get_active_controller_names=lambda: set(),
+            get_active_controller_definitions=lambda: [],
+            get_current_resource_definition=lambda: None,
+        ),
+        device_state=SimpleNamespace(current_resource_name=None),
+    )
+
+    override = PipelineOverrideService(worker).build_task_pipeline_override(
+        "Task",
+        {"GlobalMode": "default"},
+        {"GlobalMode": "saved"},
+    )
+
+    assert override == {"Node": {"mode": "saved"}}

--- a/tests/unit/test_hotkey.py
+++ b/tests/unit/test_hotkey.py
@@ -1,0 +1,74 @@
+"""Tests for hotkey conversion and pipeline override placeholders."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from maa_worker.hotkey import hotkey_value_to_codes, split_hotkey_combo
+from maa_worker.pipeline_override import PipelineOverrideService
+from models.interface import Controller, HotkeyCase, Option
+
+
+class TestSplitHotkeyCombo:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("", ("", [])),
+            (" + ", ("", [])),
+            ("A", ("A", [])),
+            (" ALT + Shift + A ", ("A", ["ALT", "Shift"])),
+        ],
+    )
+    def test_primary_is_last_nonempty_part(self, value, expected):
+        assert split_hotkey_combo(value) == expected
+
+
+class TestHotkeyValueToCodes:
+    @pytest.mark.parametrize(
+        ("controller_type", "expected"),
+        [
+            ("Win32", (0x41, 0x12, 0)),
+            ("Adb", (29, 57, 0)),
+            ("WlRoots", (30, 56, 0)),
+            (None, (0x41, 0x12, 0)),
+            ("UnknownController", (0x41, 0x12, 0)),
+        ],
+    )
+    def test_alt_a_uses_controller_key_map(self, controller_type, expected):
+        assert hotkey_value_to_codes("ALT+A", controller_type) == expected
+
+    def test_unknown_key_and_empty_value_use_zero_codes(self):
+        assert hotkey_value_to_codes("ALT+Unknown", "Win32") == (0, 0x12, 0)
+        assert hotkey_value_to_codes("", "Win32") == (0, 0, 0)
+
+
+class TestPipelineOverrideHotkey:
+    def test_replaces_modifier_and_primary_placeholders_with_integers(self):
+        option = Option(
+            type="hotkey",
+            hotkeys=[HotkeyCase(name="FightCombo")],
+            pipeline_override={
+                "key": [
+                    "{FightCombo.modifier1}",
+                    "{FightCombo.primary}",
+                ]
+            },
+        )
+        worker = SimpleNamespace(
+            interface=SimpleNamespace(option={"K": option}),
+            device=SimpleNamespace(
+                get_active_controller_definitions=lambda: [
+                    Controller(name="win", type="Win32")
+                ]
+            ),
+            device_state=SimpleNamespace(current_resource_name=None),
+        )
+        service = PipelineOverrideService(worker)
+
+        override = service._build_option_override(
+            "K",
+            {"K": {"FightCombo": "ALT+A"}},
+            set(),
+        )
+
+        assert override == {"key": [0x12, 0x41]}

--- a/tests/unit/test_interface_loader.py
+++ b/tests/unit/test_interface_loader.py
@@ -460,6 +460,99 @@ class TestLoadInterfaceModel:
         assert model.task is not None
         assert {t.name for t in model.task} == {"Extra"}
 
+    def test_import_global_options_are_deduped_and_settings_appended(self, tmp_path):
+        (tmp_path / "first.json5").write_text(
+            stdlib_json.dumps(
+                {
+                    "global_option": ["shared_option", "first_option"],
+                    "setting": [{"name": "first", "option": ["first_option"]}],
+                }
+            )
+        )
+        (tmp_path / "second.json5").write_text(
+            stdlib_json.dumps(
+                {
+                    "global_option": ["first_option", "second_option"],
+                    "setting": [{"name": "second", "option": ["second_option"]}],
+                }
+            )
+        )
+        _write_interface(
+            tmp_path,
+            {
+                "interface_version": 2,
+                "name": "Test",
+                "controller": [{"name": "adb", "type": "Adb"}],
+                "resource": [{"name": "main", "path": ["resource"]}],
+                "option": {
+                    option_name: {
+                        "type": "select",
+                        "cases": [{"name": "enabled"}],
+                    }
+                    for option_name in (
+                        "root_option",
+                        "shared_option",
+                        "first_option",
+                        "second_option",
+                    )
+                },
+                "global_option": ["root_option", "shared_option"],
+                "setting": [{"name": "root", "option": ["root_option"]}],
+                "import": ["first.json5", "second.json5"],
+            },
+        )
+
+        model = load_interface_model(tmp_path)
+
+        assert model.global_option == [
+            "root_option",
+            "shared_option",
+            "first_option",
+            "second_option",
+        ]
+        assert model.setting is not None
+        assert [section.name for section in model.setting] == [
+            "root",
+            "first",
+            "second",
+        ]
+
+    def test_duplicate_setting_name_is_rejected(self, tmp_path):
+        _write_interface(
+            tmp_path,
+            {
+                "interface_version": 2,
+                "name": "Test",
+                "controller": [{"name": "adb", "type": "Adb"}],
+                "resource": [{"name": "main", "path": ["resource"]}],
+                "setting": [{"name": "general"}, {"name": "general"}],
+            },
+        )
+
+        with pytest.raises(
+            InterfaceLoadError,
+            match=r"setting 中存在重复分区: general",
+        ):
+            load_interface_model(tmp_path)
+
+    def test_setting_unknown_option_is_rejected(self, tmp_path):
+        _write_interface(
+            tmp_path,
+            {
+                "interface_version": 2,
+                "name": "Test",
+                "controller": [{"name": "adb", "type": "Adb"}],
+                "resource": [{"name": "main", "path": ["resource"]}],
+                "setting": [{"name": "general", "option": ["missing"]}],
+            },
+        )
+
+        with pytest.raises(
+            InterfaceLoadError,
+            match=r"setting\[general\] 引用了不存在的选项: missing",
+        ):
+            load_interface_model(tmp_path)
+
     def test_pretask_single_object_is_normalized_to_list(self, tmp_path):
         _write_interface(
             tmp_path,
@@ -776,7 +869,7 @@ class TestLoadInterfaceModel:
             load_interface_model(tmp_path)
 
     def test_import_fragment_with_illegal_key(self, tmp_path):
-        """Import file with key outside {task,option,preset,import} is rejected."""
+        """Import file with key outside the allowed sections is rejected."""
         (tmp_path / "bad.json5").write_text("{controller: []}")
         _write_interface(
             tmp_path,
@@ -930,4 +1023,72 @@ class TestLoadInterfaceModel:
             },
         )
         with pytest.raises(InterfaceLoadError, match="引用了不存在的输入项"):
+            load_interface_model(tmp_path)
+
+    def test_preset_hotkey_invalid_type(self, tmp_path):
+        _write_interface(
+            tmp_path,
+            {
+                "interface_version": 2,
+                "name": "Test",
+                "controller": [{"name": "adb", "type": "Adb"}],
+                "resource": [{"name": "main", "path": ["resource"]}],
+                "task": [{"name": "A", "entry": "A", "option": ["hotkeys"]}],
+                "option": {
+                    "hotkeys": {
+                        "type": "hotkey",
+                        "hotkeys": [{"name": "toggle"}],
+                    }
+                },
+                "preset": [
+                    {
+                        "name": "P",
+                        "task": [{"name": "A", "option": {"hotkeys": "Alt+A"}}],
+                    }
+                ],
+            },
+        )
+
+        with pytest.raises(
+            InterfaceLoadError,
+            match=(r"preset\[P\]\.task\[A\]\.option\[hotkeys\] 必须是对象"),
+        ):
+            load_interface_model(tmp_path)
+
+    def test_preset_hotkey_unknown_field_is_rejected(self, tmp_path):
+        _write_interface(
+            tmp_path,
+            {
+                "interface_version": 2,
+                "name": "Test",
+                "controller": [{"name": "adb", "type": "Adb"}],
+                "resource": [{"name": "main", "path": ["resource"]}],
+                "task": [{"name": "A", "entry": "A", "option": ["hotkeys"]}],
+                "option": {
+                    "hotkeys": {
+                        "type": "hotkey",
+                        "hotkeys": [{"name": "toggle"}],
+                    }
+                },
+                "preset": [
+                    {
+                        "name": "P",
+                        "task": [
+                            {
+                                "name": "A",
+                                "option": {"hotkeys": {"unknown": "Alt+A"}},
+                            }
+                        ],
+                    }
+                ],
+            },
+        )
+
+        with pytest.raises(
+            InterfaceLoadError,
+            match=(
+                r"preset\[P\]\.task\[A\]\.option\[hotkeys\] "
+                r"引用了不存在的快捷键项: unknown"
+            ),
+        ):
             load_interface_model(tmp_path)

--- a/tests/unit/test_interface_model.py
+++ b/tests/unit/test_interface_model.py
@@ -16,6 +16,7 @@ from models.interface import (
     Resource,
     SettingSection,
     Win32Controller,
+    WlRootsController,
     _pipeline_override_contains_attach_option,
     validate_regex,
 )
@@ -121,7 +122,16 @@ class TestMacOSController:
 
     def test_invalid_input_raises(self):
         with pytest.raises(ValidationError):
-            MacOSController.model_validate({"input": "InvalidInput"})
+            MacOSController.model_validate({"input": "Invalid"})
+
+
+class TestWlRootsController:
+    def test_win32_keycode_mode(self):
+        config = WlRootsController(use_win32_vk_code=True)
+        controller = Controller(name="wayland", type="WlRoots", wlroots=config)
+
+        assert controller.wlroots is not None
+        assert controller.wlroots.use_win32_vk_code is True
 
 
 # ---------------------------------------------------------------------------
@@ -390,4 +400,36 @@ class TestInterfaceModel:
             },
         }
         with pytest.raises(ValidationError, match="至少包含一次键"):
+            InterfaceModel.model_validate(data)
+
+    def test_hotkey_default_rejects_more_than_two_modifiers(self, _base_iface_data):
+        data = {
+            **_base_iface_data,
+            "option": {
+                "shortcut": {
+                    "type": "hotkey",
+                    "hotkeys": [
+                        {"name": "run", "default": "Ctrl+Alt+Shift+A"},
+                    ],
+                }
+            },
+        }
+
+        with pytest.raises(ValidationError, match="最多支持两个修饰键"):
+            InterfaceModel.model_validate(data)
+
+    def test_hotkey_default_rejects_meta(self, _base_iface_data):
+        data = {
+            **_base_iface_data,
+            "option": {
+                "shortcut": {
+                    "type": "hotkey",
+                    "hotkeys": [
+                        {"name": "run", "default": "Meta+A"},
+                    ],
+                }
+            },
+        }
+
+        with pytest.raises(ValidationError, match="不支持 Meta/Command/Win"):
             InterfaceModel.model_validate(data)

--- a/tests/unit/test_interface_model.py
+++ b/tests/unit/test_interface_model.py
@@ -8,11 +8,13 @@ from pydantic import ValidationError
 from models.interface import (
     Controller,
     GamepadController,
+    HotkeyCase,
     InterfaceModel,
     MacOSController,
     Option,
     OptionCase,
     Resource,
+    SettingSection,
     Win32Controller,
     _pipeline_override_contains_attach_option,
     validate_regex,
@@ -221,6 +223,29 @@ class TestOption:
         with pytest.raises(ValidationError, match="inputs 不能为空"):
             Option(type="input")
 
+    def test_hotkey_requires_hotkeys(self):
+        with pytest.raises(
+            ValidationError,
+            match="当 type 为 hotkey 时，hotkeys 不能为空",
+        ):
+            Option(type="hotkey")
+
+    def test_hotkey_accepts_hotkey_cases(self):
+        option = Option(
+            type="hotkey",
+            hotkeys=[
+                HotkeyCase(
+                    name="attack",
+                    label="Attack",
+                    description="Attack shortcut",
+                    default="Alt+A",
+                )
+            ],
+        )
+        assert option.hotkeys is not None
+        assert option.hotkeys[0].name == "attack"
+        assert option.hotkeys[0].default == "Alt+A"
+
     def test_scan_select_requires_scan_dir(self):
         with pytest.raises(ValidationError, match="scan_dir 不能为空"):
             Option(type="scan_select")
@@ -244,6 +269,41 @@ class TestOption:
                 cases=[OptionCase(name="a"), OptionCase(name="b")],
                 default_case=["a"],
             )
+
+
+class TestHotkeyCase:
+    def test_parses_metadata_and_optional_default(self):
+        case = HotkeyCase(
+            name="toggle",
+            label="Toggle",
+            description="Toggle feature",
+            default="Ctrl+T",
+        )
+        assert case.name == "toggle"
+        assert case.label == "Toggle"
+        assert case.description == "Toggle feature"
+        assert case.default == "Ctrl+T"
+
+
+class TestSettingSection:
+    def test_parses_metadata_and_options(self):
+        section = SettingSection(
+            name="general",
+            label="General",
+            description="General settings",
+            icon="settings",
+            option=["language", "shortcut"],
+            default_expand=False,
+        )
+        assert section.name == "general"
+        assert section.label == "General"
+        assert section.description == "General settings"
+        assert section.icon == "settings"
+        assert section.option == ["language", "shortcut"]
+        assert section.default_expand is False
+
+    def test_default_expand_is_true(self):
+        assert SettingSection(name="general").default_expand is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pretask_service.py
+++ b/tests/unit/test_pretask_service.py
@@ -240,6 +240,39 @@ def test_option_values_aggregate_task_entry_values_and_honor_declared_defaults(
     )
 
 
+def test_option_values_prefer_task_then_global_then_default():
+    options = {
+        "mode": Option(
+            type="select",
+            cases=[OptionCase(name="default"), OptionCase(name="task")],
+            default_case="default",
+        ),
+        "tags": Option(
+            type="checkbox",
+            cases=[OptionCase(name="default"), OptionCase(name="global")],
+            default_case=["default"],
+        ),
+        "fallback": Option(
+            type="select",
+            cases=[OptionCase(name="default")],
+            default_case="default",
+        ),
+    }
+    service = PretaskService(_make_worker(options=options))
+
+    values = service._resolve_option_values(
+        Pretask(exec="pi-tool", option=["mode", "tags", "fallback"]),
+        {"task": {"mode": "task"}},
+        {"mode": "global-mode", "tags": ["global"]},
+    )
+
+    assert values == {
+        "mode": "task",
+        "tags": ["global"],
+        "fallback": "default",
+    }
+
+
 def test_pretask_runs_from_interface_base_dir(monkeypatch):
     """相对路径的 pretask 程序应相对应用根目录解析，而非进程 cwd。"""
     worker = _make_worker(pretasks=[Pretask(exec="pi-tool")])

--- a/tests/unit/test_scheduler_models.py
+++ b/tests/unit/test_scheduler_models.py
@@ -188,6 +188,14 @@ class TestScheduledTaskDeviceConfig:
         )
         assert d.device_address == "12345|1"
 
+    def test_wlroots_socket_path(self):
+        d = ScheduledTaskDeviceConfig(
+            controller_name="c",
+            device_type="WlRoots",
+            device_address=" /run/user/1000/wayland-1 ",
+        )
+        assert d.device_address == "/run/user/1000/wayland-1"
+
 
 class TestManualStartPayload:
     def test_requires_task_list(self):

--- a/tests/unit/test_task_config.py
+++ b/tests/unit/test_task_config.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from models.interface import (
     Controller,
+    HotkeyCase,
     InputCase,
     InterfaceModel,
     Option,
@@ -58,6 +59,7 @@ def _make_option(
     opt_type="select",
     cases=None,
     inputs=None,
+    hotkeys=None,
     default_case=None,
     scan_dir=None,
     scan_filter=None,
@@ -67,6 +69,7 @@ def _make_option(
         type=opt_type,
         cases=[OptionCase(name=c) if isinstance(c, str) else c for c in (cases or [])],
         inputs=inputs,
+        hotkeys=hotkeys,
         default_case=default_case,
         scan_dir=scan_dir,
         scan_filter=scan_filter,
@@ -107,6 +110,11 @@ class TestNormalizeOptionValueForStorage:
 
     def test_dict_filters_non_strings(self):
         assert _normalize_option_value_for_storage({"k": "v", 1: 2}) == {"k": "v"}
+
+    def test_hotkey_value_storage_filters_non_strings(self):
+        assert _normalize_option_value_for_storage(
+            {"attack": "Alt+A", "invalid": 1}
+        ) == {"attack": "Alt+A"}
 
     def test_invalid_type_returns_none(self):
         assert _normalize_option_value_for_storage(42) is None
@@ -297,6 +305,18 @@ class TestBuildOptionDefaults:
         defaults, _ = _build_option_defaults({"inp": opt})
         assert defaults["inp"] == {"threshold": ""}
 
+    def test_hotkey_defaults(self):
+        opt = _make_option(
+            "hotkey",
+            hotkeys=[
+                HotkeyCase(name="attack", default="Alt+A"),
+                HotkeyCase(name="defend"),
+            ],
+        )
+        defaults, types = _build_option_defaults({"combo": opt})
+        assert defaults["combo"] == {"attack": "Alt+A", "defend": ""}
+        assert types["combo"] == "object"
+
     def test_scan_select_treated_like_string(self):
         opt = _make_option(
             "scan_select",
@@ -396,6 +416,21 @@ class TestNormalizeOptionsForTask:
         assert isinstance(opt_value, dict)
         assert opt_value["host"] == "localhost"
         assert opt_value["port"] == ""
+
+    def test_hotkey_partial_update(self):
+        opt = _make_option(
+            "hotkey",
+            hotkeys=[HotkeyCase(name="attack"), HotkeyCase(name="defend")],
+        )
+        defaults, types = _build_option_defaults({"combo": opt})
+        result = _normalize_options_for_task(
+            {"combo": {"attack": "Ctrl+A", "unknown": "ignored"}},
+            {"combo": opt},
+            defaults,
+            types,
+            {},
+        )
+        assert result["combo"] == {"attack": "Ctrl+A", "defend": ""}
 
     def test_unknown_option_key_ignored(self):
         opt = _make_option("select", cases=["a"])
@@ -594,6 +629,33 @@ class TestBuildInterfacePresetSnapshot:
         assert isinstance(cfg, dict)
         assert cfg["host"] == "localhost"
         assert cfg["port"] == ""  # default preserved
+
+    def test_hotkey_option_applied(self):
+        """Preset applies a hotkey option value and preserves other defaults."""
+        opt = _make_option(
+            "hotkey",
+            hotkeys=[HotkeyCase(name="attack"), HotkeyCase(name="defend")],
+        )
+        iface = _make_interface(
+            tasks=[Task(name="T", entry="T", option=["combo"])],
+            options={"combo": opt},
+            presets=[
+                Preset(
+                    name="P",
+                    task=[
+                        PresetTask(
+                            name="T",
+                            option={"combo": {"attack": "Alt+A"}},
+                        )
+                    ],
+                )
+            ],
+        )
+        snapshot = build_interface_preset_snapshot(iface, iface.preset[0])
+        combo = snapshot.taskOptions["T"]["combo"]
+        assert isinstance(combo, dict)
+        assert combo["attack"] == "Alt+A"
+        assert combo["defend"] == ""
 
     def test_enabled_false_stays_unchecked(self):
         """Preset task with enabled=False is unchecked."""


### PR DESCRIPTION
## Sourcery 摘要

在前端、接口模型、持久化层和工作器执行流程中实现 PI v2.8.0 任务设置和快捷键配置支持。

新功能：
- 添加可配置的 PI 任务设置分区，支持本地化标签、描述、图标、嵌套选项以及持久化的全局选项值。
- 在接口架构、设置界面、任务配置、预设和流水线覆盖中支持 Win32、Android ADB 和 Wayland 控制器的快捷键选项。

错误修复：
- 在执行开始时，将持久化的全局选项值传递给每个选中的任务。

增强功能：
- 将任务选项控件重构为可复用组件，支持开关、选择框、输入框、复选框和快捷键。
- 扩展接口导入和验证功能，以安全处理全局选项、设置分区和快捷键值。
- 为新的任务设置区域和快捷键捕获状态添加本地化界面文本。

测试：
- 添加前端和后端测试覆盖，验证快捷键标准化、控制器按键代码转换、快捷键默认值和预设、设置分区验证、导入的全局选项以及全局选项执行传递。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在前端、模型、持久化层和工作器执行流程中实现 PI v2.8.0 任务设置、持久化全局选项、快捷键配置以及 Wayland 控制器支持。

新功能：
- 添加可配置的 PI 任务设置分区，支持本地化元数据、嵌套选项、图标、默认值以及持久化的全局选项值。
- 在接口定义、任务设置、预设、流水线覆盖项以及 Win32、Android ADB 和 Wayland 控制器中支持快捷键配置。
- 添加 Wayland WlRoots 控制器和设备支持，包括设备发现、持久化、验证、连接以及可配置的键码行为。

错误修复：
- 将持久化的全局选项值传递到前置任务和任务执行流程中，使选定的任务使用已配置的全局设置。

增强：
- 将任务选项控件重构为可复用组件，支持开关、选择、输入框、复选框和快捷键捕获。
- 扩展接口导入、验证、规范化、预设处理以及流水线覆盖项处理，以支持全局选项、设置分区和快捷键。
- 序列化设置写入操作，并防止过时或失败的持久化响应覆盖更新的值。
- 为任务设置和快捷键捕获状态添加本地化标签和反馈信息。

测试：
- 添加前端和后端测试，覆盖快捷键规范化和控制器键码转换。
- 添加对设置分区验证、导入的全局选项、快捷键默认值和预设、设置持久化、设备验证以及全局选项执行传递的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement PI v2.8.0 task settings, persistent global options, hotkey configuration, and Wayland controller support across the frontend, models, persistence layer, and worker execution flow.

New Features:
- Add configurable PI task settings sections with localized metadata, nested options, icons, defaults, and persisted global option values.
- Support hotkey configuration across interface definitions, task settings, presets, pipeline overrides, and Win32, Android ADB, and Wayland controllers.
- Add Wayland WlRoots controller and device support, including discovery, persistence, validation, connection, and configurable keycode behavior.

Bug Fixes:
- Pass persisted global option values into pretask and task execution so selected tasks use the configured global settings.

Enhancements:
- Refactor task option controls into reusable components for switches, selections, inputs, checkboxes, and hotkey capture.
- Extend interface import, validation, normalization, preset handling, and pipeline override processing for global options, setting sections, and hotkeys.
- Serialize settings writes and protect newer values from stale or failed persistence responses.
- Add localized labels and feedback for task settings and hotkey capture states.

Tests:
- Add frontend and backend coverage for hotkey normalization and controller keycode conversion.
- Add coverage for setting-section validation, imported global options, hotkey defaults and presets, settings persistence, device validation, and global option execution propagation.

</details>

</details>